### PR TITLE
fix: suppress macOS App Nap during background indexing, thumbnails and preview builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ Fully generated using VS Code Copilot.
 
 ## Recent changes
 
+### Bug fixes
+
+- **macOS App Nap suppression** — Background indexing, thumbnail building, and
+  preview rendering no longer stall when the display sleeps or the screen locks.
+  An `NSActivityUserInitiated` assertion is now held for the duration of each
+  background worker, preventing macOS from throttling the worker threads.
+
 ### Capture-date indexing and timeline filter
 
 Every image now stores a `captured_at` UTC timestamp in the database, resolved

--- a/src/exif_turbo/ui/workers/_macos_activity.py
+++ b/src/exif_turbo/ui/workers/_macos_activity.py
@@ -1,0 +1,95 @@
+"""macOS App Nap suppression for long-running background workers."""
+
+from __future__ import annotations
+
+import sys
+
+
+class AppNapAssertion:
+    """Holds an NSProcessInfo activity assertion to suppress macOS App Nap.
+
+    Instantiating this class immediately begins the assertion.  Call
+    :meth:`release` when the activity ends, or use the instance as a
+    context manager with ``with``.
+
+    On non-macOS platforms every operation is a silent no-op.
+    """
+
+    # NSActivityUserInitiated = 0x00FFFFFF
+    # Tells macOS the work was explicitly started by the user and must not
+    # be throttled by App Nap even when the display sleeps or screen locks.
+    _ACTIVITY_FLAGS: int = 0x00FFFFFF
+
+    def __init__(self, reason: str) -> None:
+        self._state: object = self._begin(reason)
+
+    # ── context manager protocol ──────────────────────────────────────────
+
+    def __enter__(self) -> "AppNapAssertion":
+        return self
+
+    def __exit__(self, *_: object) -> None:
+        self.release()
+
+    # ── explicit API ─────────────────────────────────────────────────────
+
+    def release(self) -> None:
+        """End the activity assertion."""
+        self._end(self._state)
+        self._state = None
+
+    # ── private helpers ──────────────────────────────────────────────────
+
+    @staticmethod
+    def _begin(reason: str) -> object:
+        if sys.platform != "darwin":
+            return None
+        try:
+            import ctypes
+
+            lib = ctypes.CDLL("libobjc.A.dylib", use_errno=True)
+            _id = ctypes.c_void_p
+
+            get_class = ctypes.CFUNCTYPE(_id, ctypes.c_char_p)(("objc_getClass", lib))
+            reg_sel   = ctypes.CFUNCTYPE(_id, ctypes.c_char_p)(("sel_registerName", lib))
+            msg0      = ctypes.CFUNCTYPE(_id, _id, _id)(("objc_msgSend", lib))
+            msg_str   = ctypes.CFUNCTYPE(_id, _id, _id, ctypes.c_char_p)(
+                ("objc_msgSend", lib)
+            )
+            msg_begin = ctypes.CFUNCTYPE(_id, _id, _id, ctypes.c_uint64, _id)(
+                ("objc_msgSend", lib)
+            )
+
+            process_info = msg0(
+                get_class(b"NSProcessInfo"),
+                reg_sel(b"processInfo"),
+            )
+            ns_reason = msg_str(
+                get_class(b"NSString"),
+                reg_sel(b"stringWithUTF8String:"),
+                reason.encode("utf-8"),
+            )
+            token = msg_begin(
+                process_info,
+                reg_sel(b"beginActivityWithOptions:reason:"),
+                AppNapAssertion._ACTIVITY_FLAGS,
+                ns_reason,
+            )
+            return (process_info, token, lib)
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _end(state: object) -> None:
+        if state is None:
+            return
+        try:
+            import ctypes
+
+            process_info, token, lib = state  # type: ignore[misc]
+            _id = ctypes.c_void_p
+            reg_sel = ctypes.CFUNCTYPE(_id, ctypes.c_char_p)(("sel_registerName", lib))
+            msg_end = ctypes.CFUNCTYPE(None, _id, _id, _id)(("objc_msgSend", lib))
+            msg_end(process_info, reg_sel(b"endActivity:"), token)
+        except Exception:  # noqa: BLE001
+            pass

--- a/src/exif_turbo/ui/workers/index_worker.py
+++ b/src/exif_turbo/ui/workers/index_worker.py
@@ -15,6 +15,7 @@ from ...data.image_index_repository import ImageIndexRepository
 from ...indexing.image_finder import ImageFinder
 from ...indexing.indexer_service import IndexerService
 from ...utils.preview_cache import preview_dir
+from ._macos_activity import AppNapAssertion
 
 
 class IndexWorker(QThread):
@@ -66,6 +67,7 @@ class IndexWorker(QThread):
         return self._cancel_event.is_set()
 
     def run(self) -> None:
+        _nap = AppNapAssertion("Indexing images")
         try:
             if self._clear_cache_dir is not None:
                 if self._clear_cache_dir.exists():
@@ -110,6 +112,8 @@ class IndexWorker(QThread):
                 self.finished.emit(count, error_count)
         except Exception as exc:
             self.failed.emit(str(exc))
+        finally:
+            _nap.release()
 
     def _gc_orphaned_cache(self, repo: ImageIndexRepository) -> None:
         """Delete cache files whose SHA-1 prefix isn't present in the DB.

--- a/src/exif_turbo/ui/workers/preview_build_worker.py
+++ b/src/exif_turbo/ui/workers/preview_build_worker.py
@@ -23,6 +23,7 @@ from ...data.image_index_repository import ImageIndexRepository
 from ...utils.preview_cache import preview_cache_name_from_stamp, preview_dir
 from ...utils.preview_render import render_preview
 from ...utils.thumb_crypto import ThumbCrypto
+from ._macos_activity import AppNapAssertion
 
 _log = logging.getLogger(__name__)
 
@@ -102,6 +103,7 @@ class PreviewBuildWorker(QThread):
     # ── QThread.run ──────────────────────────────────────────────────────
 
     def run(self) -> None:  # noqa: C901 — mirror of ThumbWorker structure
+        _nap = AppNapAssertion("Building image previews")
         try:
             repo = ImageIndexRepository(self._db_path, key=self._key)
             try:
@@ -192,6 +194,8 @@ class PreviewBuildWorker(QThread):
                 self.finished.emit(built, total)
         except Exception as exc:  # noqa: BLE001
             self.failed.emit(str(exc))
+        finally:
+            _nap.release()
 
 
 def _scan_existing(out_dir: Path, *, encrypted: bool) -> set[str]:

--- a/src/exif_turbo/ui/workers/thumb_worker.py
+++ b/src/exif_turbo/ui/workers/thumb_worker.py
@@ -22,6 +22,7 @@ from ...indexing.image_utils import RAW_EXTENSIONS, VIDEO_EXTENSIONS, orient_raw
 from ...utils.thumb_cache import thumb_cache_name_from_stamp, thumb_cache_path
 from ...utils.thumb_crypto import ThumbCrypto
 from ...utils.video_frame import extract_video_frame
+from ._macos_activity import AppNapAssertion
 
 # Pillow 12 treats some valid-but-unusual files (e.g. 16-bit RGBA PNGs with
 # large metadata chunks) as truncated.  Allow truncated reads globally so
@@ -113,6 +114,7 @@ class ThumbWorker(QThread):
         self._resume_event.set()
 
     def run(self) -> None:
+        _nap = AppNapAssertion("Building image thumbnails")
         try:
             # Read paths and stamps from the DB on this background thread —
             # keeps the main thread free so QML can paint thumbnails immediately.
@@ -284,3 +286,5 @@ class ThumbWorker(QThread):
                 self.finished.emit(cached, total_all)
         except Exception as exc:
             self.failed.emit(str(exc))
+        finally:
+            _nap.release()


### PR DESCRIPTION
## Summary

When the display sleeps or the screen locks, macOS applies **App Nap** which aggressively throttles background threads. Combined with the already-lowered thread priority (nice 10), this caused preview/thumbnail builds and indexing to nearly stall until the display woke again.

## Fix

Introduce `AppNapAssertion` — a context manager class in `ui/workers/_macos_activity.py` that holds an `NSActivityUserInitiated` assertion via `NSProcessInfo` for the duration of each worker's `run()` method.

- The Objective-C runtime is called through `ctypes` (`libobjc.A.dylib`) — no new dependencies required.
- All three background workers are covered: `IndexWorker`, `ThumbWorker`, `PreviewBuildWorker`.
- On non-macOS platforms and on any failure, the class is a silent no-op.
- Supports both context manager (`with`) and explicit `release()` usage.

Closes #4