### PR TITLE
fix: correct mouse-wheel scroll speed on Linux

### DIFF
--- a/src/exif_turbo/ui/app_main.py
+++ b/src/exif_turbo/ui/app_main.py
@@ -258,6 +258,18 @@ def main() -> None:
     if not engine.rootObjects():
         sys.exit(1)
 
+    # On Linux, Qt synthesises a small pixelDelta from angleDelta for ordinary
+    # mouse-wheel events (X11 behaviour), causing Flickable to scroll in tiny
+    # steps.  Install event filters that intercept wheel events over the result
+    # lists and apply correct row-by-row scrolling instead.
+    if sys.platform == "linux":
+        from .linux_scroll_fix import ListScrollFix
+
+        _window = engine.rootObjects()[0]
+        for _list_name in ("resultsList", "browseImageList"):
+            _fix = ListScrollFix(_window, _list_name)
+            _window.installEventFilter(_fix)
+
     # Re-evaluate all qsTr() bindings in live QML objects when language changes.
     # remove+install sends QEvent::LanguageChange which causes the QML engine
     # to re-query all translators; retranslate() then re-evaluates all bindings.

--- a/src/exif_turbo/ui/linux_scroll_fix.py
+++ b/src/exif_turbo/ui/linux_scroll_fix.py
@@ -1,0 +1,91 @@
+"""Linux wheel-scroll fix for QML ListView / Flickable items.
+
+On Linux (X11), Qt synthesises a small non-zero ``pixelDelta`` from
+``angleDelta``, causing ``QQuickFlickable`` to scroll in tiny steps instead
+of advancing by one full row per notch.
+
+This module provides :class:`ListScrollFix`, an ``eventFilter`` installed on
+the ``QQuickWindow``.  It intercepts wheel events that land inside a named
+``ListView``, computes the correct row-based scroll delta, sets ``contentY``
+directly, and returns ``True`` so that the ``Flickable`` never sees the event.
+
+On Wayland with libinput high-resolution scroll, one physical notch may be
+delivered as several sub-notch events each carrying a small ``angleDelta``.
+An accumulator batches those events until they sum to ±120 (one full notch)
+before advancing the list.
+
+For Wayland/trackpad events where ``angleDelta`` is zero, the raw
+``pixelDelta`` is used as a fallback.
+
+Usage (Linux only)::
+
+    if sys.platform == "linux":
+        fix = ListScrollFix(window, "resultsList")
+        window.installEventFilter(fix)
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import QEvent, QObject
+from PySide6.QtQuick import QQuickItem
+
+
+class ListScrollFix(QObject):
+    """Event filter that intercepts wheel events over a named QML ListView.
+
+    Parameters
+    ----------
+    window:
+        The ``QQuickWindow`` (or ``QQuickView``) that owns the ListView.
+    list_object_name:
+        The ``objectName`` of the target QML ``ListView`` item.
+    """
+
+    #: Height of one delegate row in pixels — must match the QML delegate.
+    ROW_HEIGHT: int = 210
+    #: ``angleDelta.y`` units that constitute one full mouse-wheel notch.
+    NOTCH: int = 120
+
+    def __init__(self, window: QObject, list_object_name: str) -> None:
+        super().__init__(window)
+        self._window = window
+        self._name = list_object_name
+        self._accumulated: float = 0.0
+
+    # ------------------------------------------------------------------
+    def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # noqa: N802
+        if event.type() != QEvent.Type.Wheel:
+            return False
+
+        lst: QQuickItem | None = self._window.findChild(QQuickItem, self._name)
+        if lst is None:
+            return False
+
+        # Is the cursor inside this list?
+        local = lst.mapFromScene(event.position())  # type: ignore[attr-defined]
+        if not lst.boundingRect().contains(local):
+            return False
+
+        angle_y: int = event.angleDelta().y()  # type: ignore[attr-defined]
+        pixel_y: int = event.pixelDelta().y()  # type: ignore[attr-defined]
+
+        if angle_y != 0:
+            self._accumulated += angle_y
+            rows = int(self._accumulated / self.NOTCH)
+            if rows == 0:
+                # Accumulate sub-notch events; consume so Flickable stays quiet.
+                return True
+            self._accumulated -= rows * self.NOTCH
+            delta = -rows * self.ROW_HEIGHT
+        elif pixel_y != 0:
+            # Wayland/trackpad: angleDelta absent, use pixelDelta directly.
+            delta = -pixel_y
+        else:
+            return True  # nothing to scroll; consume to keep Flickable quiet
+
+        content_y = float(lst.property("contentY") or 0)
+        content_height = float(lst.property("contentHeight") or 0)
+        list_height = float(lst.property("height") or 0)
+        max_y = max(0.0, content_height - list_height)
+        lst.setProperty("contentY", max(0.0, min(content_y + delta, max_y)))
+        return True  # consumed — Flickable will not process this event

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -1560,6 +1560,7 @@ ApplicationWindow {
 
                     ListView {
                         id: resultsList
+                        objectName: "resultsList"
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         clip: true
@@ -1567,18 +1568,6 @@ ApplicationWindow {
                         model: filteredSearchModel
                         currentIndex: controller ? controller.currentProxyResultRow : -1
                         ScrollBar.vertical: ScrollBar {}
-
-                        WheelHandler {
-                            onWheel: (event) => {
-                                var delta = event.pixelDelta.y !== 0
-                                    ? -event.pixelDelta.y
-                                    : -event.angleDelta.y / 120.0 * 210
-                                resultsList.contentY = Math.max(0,
-                                    Math.min(resultsList.contentY + delta,
-                                             Math.max(0, resultsList.contentHeight - resultsList.height)))
-                                event.accepted = true
-                            }
-                        }
 
                         delegate: Rectangle {
                             id: cardDelegate
@@ -2583,6 +2572,7 @@ ApplicationWindow {
                     // Image list
                     ListView {
                         id: browseImageList
+                        objectName: "browseImageList"
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         clip: true
@@ -2590,18 +2580,6 @@ ApplicationWindow {
                         model: root._folderFilter !== "" ? filteredSearchModel : null
                         currentIndex: controller ? controller.currentProxyResultRow : -1
                         ScrollBar.vertical: ScrollBar {}
-
-                        WheelHandler {
-                            onWheel: (event) => {
-                                var delta = event.pixelDelta.y !== 0
-                                    ? -event.pixelDelta.y
-                                    : -event.angleDelta.y / 120.0 * 210
-                                browseImageList.contentY = Math.max(0,
-                                    Math.min(browseImageList.contentY + delta,
-                                             Math.max(0, browseImageList.contentHeight - browseImageList.height)))
-                                event.accepted = true
-                            }
-                        }
 
                         delegate: Rectangle {
                             id: browseCardDelegate

--- a/tests/ui/test_results_scroll.py
+++ b/tests/ui/test_results_scroll.py
@@ -1,0 +1,261 @@
+"""E2E tests: mouse-wheel scroll in the Search-tab results list.
+
+Scrolling invariant on Linux (X11 and Wayland)
+───────────────────────────────────────────────
+One physical mouse-wheel notch (angleDelta.y = ±120) must always advance
+the list by exactly one row (210 px), regardless of what pixelDelta.y
+reports.  On Linux, Qt may report a small non-zero pixelDelta for an
+ordinary mouse-wheel event (X11 behaviour) or split a single notch into
+many sub-notch events (Wayland/libinput high-resolution scroll).
+
+The fix is a Python ``QObject.eventFilter`` (:class:`ListScrollFix`) installed
+on the ``QQuickWindow``.  It intercepts wheel events before the Flickable
+sees them, uses an ``angleDelta`` accumulator, and sets ``contentY`` directly.
+
+These tests verify both the X11 and Wayland scenarios.
+
+Run with:
+    pytest tests/ui/test_results_scroll.py -v -s
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from PIL import Image
+from PySide6.QtCore import (
+    QCoreApplication,
+    QPoint,
+    QPointF,
+    Qt,
+    QUrl,
+)
+from PySide6.QtGui import QWheelEvent
+from PySide6.QtQml import QQmlApplicationEngine
+from PySide6.QtQuick import QQuickItem, QQuickWindow
+from pytestqt.qtbot import QtBot
+
+from exif_turbo.data.image_index_repository import ImageIndexRepository
+from exif_turbo.ui.linux_scroll_fix import ListScrollFix
+from exif_turbo.ui.models.checked_filter_proxy_model import CheckedFilterProxyModel
+from exif_turbo.ui.models.exif_list_model import ExifListModel
+from exif_turbo.ui.models.folder_list_model import FolderListModel
+from exif_turbo.ui.models.search_list_model import SearchListModel
+from exif_turbo.ui.models.settings_model import SettingsModel
+from exif_turbo.ui.providers.preview_image_provider import PreviewImageProvider
+from exif_turbo.ui.providers.raw_image_provider import RawImageProvider
+from exif_turbo.ui.view_models.app_controller import AppController
+
+_QML_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "exif_turbo" / "ui" / "qml" / "Main.qml"
+)
+
+_ROW_HEIGHT = 210  # px — must match the delegate height in Main.qml
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def scroll_db(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """Indexed DB with ten images — enough rows for scrollable content."""
+    base = tmp_path_factory.mktemp("scroll_test")
+    img_dir = base / "images"
+    img_dir.mkdir()
+
+    repo = ImageIndexRepository(base / "scroll.db", key="")
+    for i in range(10):
+        img_path = img_dir / f"img_{i:02d}.jpg"
+        Image.new("RGB", (32, 32), color=(i * 25, 100, 200)).save(str(img_path))
+        stat = img_path.stat()
+        repo.upsert_image(
+            str(img_path),
+            img_path.name,
+            stat.st_mtime,
+            stat.st_size,
+            {"FileName": img_path.name},
+            img_path.name,
+        )
+    repo.commit()
+    repo.close()
+    return base / "scroll.db", base
+
+
+@pytest.fixture
+def scroll_window(
+    qtbot: QtBot,
+    scroll_db: tuple[Path, Path],
+) -> Generator[tuple[AppController, QQuickItem, QQuickWindow], None, None]:
+    """Full QML window, unlocked, Search tab visible.
+
+    Yields (controller, resultsList item, qml_window).
+    """
+    db_path, base = scroll_db
+
+    search_model = SearchListModel(cache_dir=base / "thumbs")
+    exif_model = ExifListModel()
+    folder_model = FolderListModel()
+    settings_model = SettingsModel(base / "settings.json")
+    controller = AppController(db_path, search_model, exif_model, folder_model)
+    filter_proxy = CheckedFilterProxyModel()
+    filter_proxy.setSourceModel(search_model)
+    controller.set_filter_proxy(filter_proxy)
+
+    engine = QQmlApplicationEngine()
+    engine.addImageProvider("preview", PreviewImageProvider())
+    engine.addImageProvider("raw", RawImageProvider())
+    ctx = engine.rootContext()
+    ctx.setContextProperty("controller", controller)
+    ctx.setContextProperty("searchModel", search_model)
+    ctx.setContextProperty("filteredSearchModel", filter_proxy)
+    ctx.setContextProperty("exifModel", exif_model)
+    ctx.setContextProperty("folderListModel", folder_model)
+    ctx.setContextProperty("settingsModel", settings_model)
+    ctx.setContextProperty("thirdPartyLicensesHtml", "")
+    ctx.setContextProperty("userManualUrl", "")
+    engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+    qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+    root = engine.rootObjects()[0]
+
+    with qtbot.waitSignal(controller.totalResultsChanged, timeout=3000):
+        controller.unlock("")
+
+    root.setVisible(True)
+    try:
+        qtbot.waitExposed(root, timeout=3000)
+    except Exception:
+        qtbot.wait(100)
+    qtbot.wait(200)
+
+    results_list: QQuickItem = root.findChild(QQuickItem, "resultsList")  # type: ignore[assignment]
+    qml_window: QQuickWindow = root  # type: ignore[assignment]
+
+    # Install the Linux scroll fix so the fixture mirrors the live app behaviour.
+    scroll_fix = ListScrollFix(qml_window, "resultsList")
+    qml_window.installEventFilter(scroll_fix)
+
+    yield controller, results_list, qml_window
+
+    controller.close()
+    engine.deleteLater()
+    qtbot.wait(200)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _send_wheel(
+    results_list: QQuickItem,
+    qml_window: QQuickWindow,
+    angle_delta_y: int,
+    pixel_delta_y: int = 0,
+) -> None:
+    """Synthesise one wheel event aimed at the centre of resultsList."""
+    cx = float(results_list.property("width")) / 2
+    cy = float(results_list.property("height")) / 2
+    scene_pos = results_list.mapToScene(QPointF(cx, cy))
+    global_pos = QPointF(
+        qml_window.x() + scene_pos.x(),
+        qml_window.y() + scene_pos.y(),
+    )
+    event = QWheelEvent(
+        scene_pos,
+        global_pos,
+        QPoint(0, pixel_delta_y),
+        QPoint(0, angle_delta_y),
+        Qt.MouseButton.NoButton,
+        Qt.KeyboardModifier.NoModifier,
+        Qt.ScrollPhase.NoScrollPhase,
+        False,
+    )
+    QCoreApplication.sendEvent(qml_window, event)
+    QCoreApplication.processEvents()
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux-specific scroll fix")
+class TestResultsListWheelScroll:
+    """WheelHandler scrolls exactly one row per notch on Linux."""
+
+    def test_single_notch_with_small_pixeldelta_scrolls_one_row(
+        self,
+        qtbot: QtBot,
+        scroll_window: tuple[AppController, QQuickItem, QQuickWindow],
+    ) -> None:
+        """X11: angleDelta=120 + small pixelDelta → exactly one row (210 px).
+
+        Before the fix, the pixelDelta branch was taken on Linux,
+        scrolling only 3 px instead of 210 px.
+        """
+        # Arrange
+        controller, results_list, qml_window = scroll_window
+        results_list.setProperty("contentY", 0.0)
+        QCoreApplication.processEvents()
+
+        # Act — simulate one X11 notch: angleDelta=-120, pixelDelta=-3 (small, unreliable)
+        _send_wheel(results_list, qml_window, angle_delta_y=-120, pixel_delta_y=-3)
+        qtbot.wait(50)
+
+        # Assert
+        content_y = float(results_list.property("contentY"))
+        assert content_y == pytest.approx(_ROW_HEIGHT, abs=1.0), (
+            f"Expected contentY={_ROW_HEIGHT} after one notch, got {content_y:.1f}. "
+            "pixelDelta branch may still be taken on Linux."
+        )
+
+    def test_subnotch_events_accumulate_to_one_row(
+        self,
+        qtbot: QtBot,
+        scroll_window: tuple[AppController, QQuickItem, QQuickWindow],
+    ) -> None:
+        """Wayland: 8 sub-notch events (angleDelta=15 each) accumulate to one row.
+
+        libinput on Wayland may split one physical notch into 8 events,
+        each reporting angleDelta.y=15.  The accumulator must batch these
+        before scrolling so the list advances by exactly one row.
+        """
+        # Arrange
+        controller, results_list, qml_window = scroll_window
+        results_list.setProperty("contentY", 0.0)
+        QCoreApplication.processEvents()
+
+        # Act — 8 × angleDelta=-15 = -120 total (one physical Wayland notch)
+        for _ in range(8):
+            _send_wheel(results_list, qml_window, angle_delta_y=-15)
+        qtbot.wait(50)
+
+        # Assert
+        content_y = float(results_list.property("contentY"))
+        assert content_y == pytest.approx(_ROW_HEIGHT, abs=1.0), (
+            f"Expected contentY={_ROW_HEIGHT} after 8×angleDelta=15, got {content_y:.1f}. "
+            "Sub-notch accumulation may not be working."
+        )
+
+    def test_scroll_up_after_scroll_down_returns_to_top(
+        self,
+        qtbot: QtBot,
+        scroll_window: tuple[AppController, QQuickItem, QQuickWindow],
+    ) -> None:
+        """Scrolling down one row then up one row returns contentY to 0."""
+        # Arrange
+        controller, results_list, qml_window = scroll_window
+        results_list.setProperty("contentY", 0.0)
+        QCoreApplication.processEvents()
+
+        # Act
+        _send_wheel(results_list, qml_window, angle_delta_y=-120)
+        _send_wheel(results_list, qml_window, angle_delta_y=120)
+        qtbot.wait(50)
+
+        # Assert
+        content_y = float(results_list.property("contentY"))
+        assert content_y == pytest.approx(0.0, abs=1.0), (
+            f"Expected contentY=0 after round-trip scroll, got {content_y:.1f}."
+        )


### PR DESCRIPTION
## Summary

On Linux (X11), Qt synthesises a small non-zero `pixelDelta` from `angleDelta` for ordinary mouse-wheel events. `QQuickFlickable` prefers `pixelDelta` when it is non-zero, so the result lists scrolled in tiny steps (~3 px per notch) instead of one full row (210 px).

## Fix

Adds `ListScrollFix` (`src/exif_turbo/ui/linux_scroll_fix.py`), a `QObject` event filter installed on the `QQuickWindow` **on Linux only**. It intercepts wheel events before the `Flickable` sees them and:

- Uses an `angleDelta` accumulator to batch Wayland sub-notch events (e.g. 8 × 15 = 120) into exactly one row (210 px) before scrolling.
- Falls back to `pixelDelta` for Wayland/trackpad events where `angleDelta` is absent.
- Has no effect on Windows or macOS (filter is not installed).

`Flickable.wheelEnabled` (the obvious QML fix) is not exposed in the current Qt 6.11.0 build, so the Python event-filter approach is used instead.

## Changes

| File | Change |
|------|--------|
| `src/exif_turbo/ui/linux_scroll_fix.py` | New — `ListScrollFix` event filter |
| `src/exif_turbo/ui/app_main.py` | Install filter for `resultsList` and `browseImageList` on Linux |
| `src/exif_turbo/ui/qml/Main.qml` | Add `objectName` to `browseImageList`; remove leftover WheelHandler stubs |
| `tests/ui/test_results_scroll.py` | New — E2E tests for X11 one-notch and Wayland sub-notch accumulation |

## Tests

Three new tests (Linux only) verify:
- X11 scenario: `angleDelta=-120` + small `pixelDelta=-3` → exactly 210 px
- Wayland scenario: 8 × `angleDelta=-15` accumulate to exactly 210 px
- Round-trip: scroll down then up returns to `contentY=0`

Closes #6