### PR TITLE
fix(#9): replace Flickable+Row with Flow in timeline filter strip

### DIFF
--- a/scripts/populate_translations.py
+++ b/scripts/populate_translations.py
@@ -229,6 +229,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "TAKEN": "AUFNAHMEDATUM",
         "Shift-click to extend range": "Shift-Klick zum Erweitern des Bereichs",
         "Clear date filter": "Datumsfilter zur\u00fccksetzen",
+        "Filter by capture date \u2014 click a year to select it, Shift-click to extend the range": "Nach Aufnahmedatum filtern \u2014 Klicke auf ein Jahr zum Ausw\u00e4hlen, Shift-Klick zum Erweitern des Bereichs",
         # ── Preview cache & bulk-delete ──────────────────────────────────────
         "&Delete Marked Images (%1 selected)": "Markierte Bilder l\u00f6schen (%1 ausgew\u00e4hlt)",
         "%1 of %2 previews cached": "%1 von %2 Vorschaubilder zwischengespeichert",
@@ -492,6 +493,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "TAKEN": "PRISE DE VUE",
         "Shift-click to extend range": "Maj+clic pour \u00e9tendre la plage",
         "Clear date filter": "Effacer le filtre de date",
+        "Filter by capture date \u2014 click a year to select it, Shift-click to extend the range": "Filtrer par date de prise de vue \u2014 cliquez sur une ann\u00e9e pour la s\u00e9lectionner, Maj+clic pour \u00e9tendre la plage",
         # ── Preview cache & bulk-delete ──────────────────────────────────────
         "&Delete Marked Images (%1 selected)": "Supprimer les images marqu\u00e9es (%1 s\u00e9lectionn\u00e9e(s))",
         "%1 of %2 previews cached": "%1 sur %2 aper\u00e7us en cache",
@@ -760,6 +762,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "TAKEN": "DATA SCATTO",
         "Shift-click to extend range": "Maiusc+clic per estendere l\u2019intervallo",
         "Clear date filter": "Cancella filtro data",
+        "Filter by capture date \u2014 click a year to select it, Shift-click to extend the range": "Filtra per data di scatto \u2014 clicca su un anno per selezionarlo, Maiusc+clic per estendere l\u2019intervallo",
         # ── Preview cache & bulk-delete ──────────────────────────────────────
         "&Delete Marked Images (%1 selected)": "Elimina immagini contrassegnate (%1 selezionata/e)",
         "%1 of %2 previews cached": "%1 di %2 anteprime in cache",
@@ -1025,6 +1028,7 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "TAKEN": "FOTOGRAFÀ",
         "Shift-click to extend range": "Shift-clic per stender il rom",
         "Clear date filter": "Stizzar il filter da data",
+        "Filter by capture date \u2014 click a year to select it, Shift-click to extend the range": "Filtrar tenor data da fotografar \u2014 clicca sin in onn per selecziunar, Shift-clic per stender il rom",
         # ── Preview cache & bulk-delete ──────────────────────────────────────
         "&Delete Marked Images (%1 selected)": "Stizzar maletgs marcads (%1 seletgad(s))",
         "%1 of %2 previews cached": "%1 da %2 previstas en cache",

--- a/src/exif_turbo/i18n/locales/de/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/de/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-05-22 16:47+0200\n"
+"POT-Creation-Date: 2026-05-23 10:45+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -140,8 +140,8 @@ msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
 "The cache has been cleared and will be rebuilt."
 msgstr ""
-"Das Passwort wurde geändert, aber der Miniaturansicht-Cache konnte nicht"
-" neu verschlüsselt werden ({error}). Der Cache wurde geleert und wird neu "
+"Das Passwort wurde geändert, aber der Miniaturansicht-Cache konnte nicht "
+"neu verschlüsselt werden ({error}). Der Cache wurde geleert und wird neu "
 "erstellt."
 
 #: src/exif_turbo/ui/view_models/app_controller.py:1482
@@ -555,6 +555,14 @@ msgid "File size"
 msgstr "Dateigrösse"
 
 #: QML
+msgid ""
+"Filter by capture date — click a year to select it, Shift-click to extend"
+" the range"
+msgstr ""
+"Nach Aufnahmedatum filtern — Klicke auf ein Jahr zum Auswählen, Shift-"
+"Klick zum Erweitern des Bereichs"
+
+#: QML
 msgid "Find"
 msgstr "Suchen"
 
@@ -963,10 +971,6 @@ msgstr "Kleinste"
 #: QML
 msgid "Sort"
 msgstr "Sortieren"
-
-#: QML
-msgid "TAKEN"
-msgstr "AUFNAHMEDATUM"
 
 #: QML
 msgid "Tag"
@@ -1797,4 +1801,7 @@ msgstr "← Ordner auswählen, um Bilder zu durchsuchen"
 
 #~ msgid "Reset Database…"
 #~ msgstr "Datenbank zurücksetzen…"
+
+#~ msgid "TAKEN"
+#~ msgstr "AUFNAHMEDATUM"
 

--- a/src/exif_turbo/i18n/locales/fr/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/fr/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-05-22 16:47+0200\n"
+"POT-Creation-Date: 2026-05-23 10:45+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -555,6 +555,14 @@ msgid "File size"
 msgstr "Taille du fichier"
 
 #: QML
+msgid ""
+"Filter by capture date — click a year to select it, Shift-click to extend"
+" the range"
+msgstr ""
+"Filtrer par date de prise de vue — cliquez sur une année pour la "
+"sélectionner, Maj+clic pour étendre la plage"
+
+#: QML
 msgid "Find"
 msgstr "Rechercher"
 
@@ -965,10 +973,6 @@ msgstr "Plus petit"
 #: QML
 msgid "Sort"
 msgstr "Trier"
-
-#: QML
-msgid "TAKEN"
-msgstr "PRISE DE VUE"
 
 #: QML
 msgid "Tag"
@@ -1809,4 +1813,7 @@ msgstr "← Sélectionner un dossier pour parcourir les images"
 
 #~ msgid "Reset Database…"
 #~ msgstr "Réinitialiser la base de données…"
+
+#~ msgid "TAKEN"
+#~ msgstr "PRISE DE VUE"
 

--- a/src/exif_turbo/i18n/locales/it/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/it/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-05-22 16:47+0200\n"
+"POT-Creation-Date: 2026-05-23 10:45+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: it\n"
@@ -553,6 +553,14 @@ msgid "File size"
 msgstr "Dimensione file"
 
 #: QML
+msgid ""
+"Filter by capture date — click a year to select it, Shift-click to extend"
+" the range"
+msgstr ""
+"Filtra per data di scatto — clicca su un anno per selezionarlo, "
+"Maiusc+clic per estendere l’intervallo"
+
+#: QML
 msgid "Find"
 msgstr "Trova"
 
@@ -963,10 +971,6 @@ msgstr "Più piccolo"
 #: QML
 msgid "Sort"
 msgstr "Ordina"
-
-#: QML
-msgid "TAKEN"
-msgstr "DATA SCATTO"
 
 #: QML
 msgid "Tag"
@@ -1807,4 +1811,7 @@ msgstr "← Seleziona una cartella per sfogliare le immagini"
 
 #~ msgid "Reset Database…"
 #~ msgstr "Ripristina database…"
+
+#~ msgid "TAKEN"
+#~ msgstr "DATA SCATTO"
 

--- a/src/exif_turbo/i18n/locales/rm/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/rm/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-05-22 16:47+0200\n"
+"POT-Creation-Date: 2026-05-23 10:45+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: rm\n"
@@ -552,6 +552,14 @@ msgid "File size"
 msgstr "Grondezza da datoteca"
 
 #: QML
+msgid ""
+"Filter by capture date — click a year to select it, Shift-click to extend"
+" the range"
+msgstr ""
+"Filtrar tenor data da fotografar — clicca sin in onn per selecziunar, "
+"Shift-clic per stender il rom"
+
+#: QML
 msgid "Find"
 msgstr "Tschertgar"
 
@@ -959,10 +967,6 @@ msgstr "Pli pitschens"
 #: QML
 msgid "Sort"
 msgstr "Sortir"
-
-#: QML
-msgid "TAKEN"
-msgstr "FOTOGRAFÀ"
 
 #: QML
 msgid "Tag"
@@ -1798,4 +1802,7 @@ msgstr "← Tscherner ina cartella per navigar ils maletgs"
 
 #~ msgid "Reset Database…"
 #~ msgstr "Resettar banca da datas…"
+
+#~ msgid "TAKEN"
+#~ msgstr "FOTOGRAFÀ"
 

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -1374,12 +1374,23 @@ ApplicationWindow {
                     // Contains a mini histogram (year bars) + From/To year pickers.
                     Rectangle {
                         id: dateFilterRow
+                        objectName: "dateFilterRow"
                         Layout.fillWidth: true
                         readonly property bool _hasYears: root._years.length > 0
                         readonly property bool _filterActive: root._dateFrom > 0 || root._dateTo > 0
-                        implicitHeight: _hasYears ? 68 : 0
+                        implicitHeight: _hasYears ? histFlow.implicitHeight + 8 : 0
                         visible: _hasYears
                         color: Qt.rgba(root._accentColor.r, root._accentColor.g, root._accentColor.b, 0.04)
+
+                        // Tooltip for the whole filter strip (non-blocking).
+                        MouseArea {
+                            anchors.fill: parent
+                            acceptedButtons: Qt.NoButton
+                            hoverEnabled: true
+                            ToolTip.text: qsTr("Filter by capture date — click a year to select it, Shift-click to extend the range")
+                            ToolTip.visible: containsMouse
+                            ToolTip.delay: 600
+                        }
 
                         // Compute histogram max for bar height scaling.
                         readonly property int _maxCount: {
@@ -1406,95 +1417,85 @@ ApplicationWindow {
                             anchors { fill: parent; leftMargin: 8; rightMargin: 8; topMargin: 4; bottomMargin: 4 }
                             spacing: 8
 
-                            FloatingBadge { text: qsTr("TAKEN") }
-
                             // ── Mini histogram ────────────────────────────
-                            Flickable {
+                            Flow {
+                                id: histFlow
                                 Layout.fillWidth: true
-                                Layout.fillHeight: true
-                                contentWidth: histRow.implicitWidth
-                                flickableDirection: Flickable.HorizontalFlick
-                                clip: true
+                                spacing: 2
 
-                                Row {
-                                    id: histRow
-                                    anchors.bottom: parent.bottom
-                                    spacing: 2
+                                Repeater {
+                                    model: root._years
+                                    delegate: Item {
+                                        required property var modelData
+                                        width: 18
+                                        height: 60
 
-                                    Repeater {
-                                        model: root._years
-                                        delegate: Item {
-                                            required property var modelData
-                                            width: 18
-                                            height: dateFilterRow.height - 8
+                                        readonly property bool _inRange:
+                                            modelData.year >= dateFilterRow._activeFrom &&
+                                            modelData.year <= dateFilterRow._activeTo
+                                        readonly property int _barH:
+                                            Math.max(3, Math.round(
+                                                (modelData.count / dateFilterRow._maxCount) * (height - 18)
+                                            ))
 
-                                            readonly property bool _inRange:
-                                                modelData.year >= dateFilterRow._activeFrom &&
-                                                modelData.year <= dateFilterRow._activeTo
-                                            readonly property int _barH:
-                                                Math.max(3, Math.round(
-                                                    (modelData.count / dateFilterRow._maxCount) * (height - 18)
-                                                ))
+                                        // Year label
+                                        Label {
+                                            anchors { bottom: bar.top; horizontalCenter: parent.horizontalCenter; bottomMargin: 1 }
+                                            text: modelData.year.toString()
+                                            font.pixelSize: 8
+                                            rotation: -45
+                                            transformOrigin: Item.Center
+                                            opacity: _inRange ? 1.0 : 0.4
+                                            color: _inRange ? Material.foreground : Material.foreground
+                                        }
 
-                                            // Year label
-                                            Label {
-                                                anchors { bottom: bar.top; horizontalCenter: parent.horizontalCenter; bottomMargin: 1 }
-                                                text: modelData.year.toString()
-                                                font.pixelSize: 8
-                                                rotation: -45
-                                                transformOrigin: Item.Center
-                                                opacity: _inRange ? 1.0 : 0.4
-                                                color: _inRange ? Material.foreground : Material.foreground
-                                            }
+                                        // Bar
+                                        Rectangle {
+                                            id: bar
+                                            anchors { bottom: parent.bottom; horizontalCenter: parent.horizontalCenter }
+                                            width: 14
+                                            height: parent._barH
+                                            radius: 2
+                                            color: parent._inRange
+                                                   ? root._accentColor
+                                                   : Qt.rgba(root._accentColor.r, root._accentColor.g, root._accentColor.b, 0.25)
 
-                                            // Bar
-                                            Rectangle {
-                                                id: bar
-                                                anchors { bottom: parent.bottom; horizontalCenter: parent.horizontalCenter }
-                                                width: 14
-                                                height: parent._barH
-                                                radius: 2
-                                                color: parent._inRange
-                                                       ? root._accentColor
-                                                       : Qt.rgba(root._accentColor.r, root._accentColor.g, root._accentColor.b, 0.25)
+                                            Behavior on height { NumberAnimation { duration: 150 } }
+                                        }
 
-                                                Behavior on height { NumberAnimation { duration: 150 } }
-                                            }
-
-                                            MouseArea {
-                                                anchors.fill: parent
-                                                cursorShape: Qt.PointingHandCursor
-                                                hoverEnabled: true
-                                                onClicked: (mouse) => {
-                                                    var yr = modelData.year
-                                                    var yStart = Math.floor(Date.UTC(yr,   0, 1) / 1000)
-                                                    var yEnd   = Math.floor(Date.UTC(yr+1, 0, 1) / 1000) - 1
-                                                    if (dateFilterRow._activeFrom === yr && dateFilterRow._activeTo === yr
-                                                            && root._dateFrom > 0) {
-                                                        // clicking the already-selected single year → clear
-                                                        controller.clearDateFilter()
-                                                    } else if (root._dateFrom > 0 && (mouse.modifiers & Qt.ShiftModifier)) {
-                                                        // shift-click → extend range to include this year
-                                                        var fromTs = yr < dateFilterRow._activeFrom
-                                                            ? yStart
-                                                            : Math.floor(Date.UTC(dateFilterRow._activeFrom, 0, 1) / 1000)
-                                                        var toTs = yr > dateFilterRow._activeTo
-                                                            ? yEnd
-                                                            : Math.floor(Date.UTC(dateFilterRow._activeTo + 1, 0, 1) / 1000) - 1
-                                                        controller.setDateFilter(fromTs, toTs)
-                                                    } else {
-                                                        controller.setDateFilter(yStart, yEnd)
-                                                    }
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            cursorShape: Qt.PointingHandCursor
+                                            hoverEnabled: true
+                                            onClicked: (mouse) => {
+                                                var yr = modelData.year
+                                                var yStart = Math.floor(Date.UTC(yr,   0, 1) / 1000)
+                                                var yEnd   = Math.floor(Date.UTC(yr+1, 0, 1) / 1000) - 1
+                                                if (dateFilterRow._activeFrom === yr && dateFilterRow._activeTo === yr
+                                                        && root._dateFrom > 0) {
+                                                    // clicking the already-selected single year → clear
+                                                    controller.clearDateFilter()
+                                                } else if (root._dateFrom > 0 && (mouse.modifiers & Qt.ShiftModifier)) {
+                                                    // shift-click → extend range to include this year
+                                                    var fromTs = yr < dateFilterRow._activeFrom
+                                                        ? yStart
+                                                        : Math.floor(Date.UTC(dateFilterRow._activeFrom, 0, 1) / 1000)
+                                                    var toTs = yr > dateFilterRow._activeTo
+                                                        ? yEnd
+                                                        : Math.floor(Date.UTC(dateFilterRow._activeTo + 1, 0, 1) / 1000) - 1
+                                                    controller.setDateFilter(fromTs, toTs)
+                                                } else {
+                                                    controller.setDateFilter(yStart, yEnd)
                                                 }
-                                                ToolTip.text: {
-                                                    var base = modelData.year + ": " + modelData.count + " " + qsTr("images")
-                                                    if (root._dateFrom > 0 && !(dateFilterRow._activeFrom === modelData.year && dateFilterRow._activeTo === modelData.year))
-                                                        return base + "\n" + qsTr("Shift-click to extend range")
-                                                    return base
-                                                }
-                                                ToolTip.visible: containsMouse
-                                                ToolTip.delay: 400
                                             }
+                                            ToolTip.text: {
+                                                var base = modelData.year + ": " + modelData.count + " " + qsTr("images")
+                                                if (root._dateFrom > 0 && !(dateFilterRow._activeFrom === modelData.year && dateFilterRow._activeTo === modelData.year))
+                                                    return base + "\n" + qsTr("Shift-click to extend range")
+                                                return base
+                                            }
+                                            ToolTip.visible: containsMouse
+                                            ToolTip.delay: 400
                                         }
                                     }
                                 }

--- a/tests/ui/test_timeline_filter_wrap.py
+++ b/tests/ui/test_timeline_filter_wrap.py
@@ -1,0 +1,278 @@
+"""E2E tests: Timeline Filter year bars must wrap instead of being clipped.
+
+Bug
+───
+The date-filter histogram (``dateFilterRow``) uses a ``Flickable + Row`` to
+display per-year bars.  The ``dateFilterRow`` has a fixed
+``implicitHeight: 68``.  When there are more year bars than fit horizontally
+in the panel, the ``Flickable`` silently clips the overflow — bars beyond
+the visible edge are invisible and there is no scroll affordance shown to the
+user.
+
+Expected behaviour
+──────────────────
+When the total width of all year bars exceeds the available panel width, the
+histogram container must grow taller so that the excess bars wrap to
+additional rows.  Every year bar must be reachable without horizontal
+scrolling.
+
+How the test proves the bug
+───────────────────────────
+The test seeds the database with 40 years of images (1985–2024).  At the
+default 1200 px window width the left panel is ≈600 px wide, leaving ≈500 px
+for bars; 40 bars × 20 px = 800 px clearly overflows.
+
+``histFlickable`` has ``objectName: "histFlickable"`` so it can be located
+with ``findChild``.  The invariant checked is:
+
+  ``histFlickable.contentWidth ≤ histFlickable.width``
+
+This assertion *fails* with the current ``Flickable`` layout because
+``contentWidth (800 px) > width (≈500 px)`` — proving the bug.
+
+Once the layout is changed to a wrapping ``Flow``, the ``Flickable`` is
+removed and the assertion is vacuously satisfied (the ``Flickable`` object no
+longer exists).  A secondary assertion then verifies that ``dateFilterRow``
+grew taller than the original 68 px single-row height.
+
+Run with::
+
+    pytest tests/ui/test_timeline_filter_wrap.py -v -s
+
+A screenshot is written to the OS temp directory each run.
+"""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from PIL import Image
+from PySide6.QtCore import QUrl
+from PySide6.QtQml import QQmlApplicationEngine
+from PySide6.QtQuick import QQuickItem
+from pytestqt.qtbot import QtBot
+
+from exif_turbo.data.image_index_repository import ImageIndexRepository
+from exif_turbo.ui.models.exif_list_model import ExifListModel
+from exif_turbo.ui.models.checked_filter_proxy_model import CheckedFilterProxyModel
+from exif_turbo.ui.models.folder_list_model import FolderListModel
+from exif_turbo.ui.models.search_list_model import SearchListModel
+from exif_turbo.ui.models.settings_model import SettingsModel
+from exif_turbo.ui.providers.preview_image_provider import PreviewImageProvider
+from exif_turbo.ui.providers.raw_image_provider import RawImageProvider
+from exif_turbo.ui.providers.thumb_image_provider import ThumbnailImageProvider
+from exif_turbo.ui.view_models.app_controller import AppController
+from exif_turbo.utils.thumb_cache import thumb_cache_name_from_stamp
+
+_QML_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "exif_turbo" / "ui" / "qml" / "Main.qml"
+)
+
+# Sample images from the schweiz test collection, cycled across all years.
+_SAMPLE_DIR = Path(__file__).resolve().parents[1] / "sample-data" / "schweiz"
+_SAMPLE_JPGS: list[Path] = sorted(_SAMPLE_DIR.rglob("*.jpg"))
+
+# Years seeded into the DB — 65 years guarantees bar overflow at any normal panel width.
+# 65 bars × 20 px/bar = 1300 px, far exceeding any reasonable left-panel width.
+_YEARS = list(range(1960, 2025))
+
+# Each bar is 18 px wide with 2 px spacing → 20 px per bar.
+_BAR_STEP_PX = 20
+
+# Original fixed height in the unfixed QML (single-row height used as sentinel).
+_ORIGINAL_SINGLE_ROW_HEIGHT = 68
+
+# Minimum bar pixels before the layout is considered ready.
+_LAYOUT_READY_MIN_CONTENT_PX = 200
+
+# Thumbnail size written to the cache (matches app default).
+_THUMB_SIZE = (144, 144)
+
+# ── fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def timeline_db(tmp_path_factory: pytest.TempPathFactory) -> tuple[Path, Path]:
+    """DB with one image per year from 1960–2024 using real sample images.
+
+    Each year gets a resized copy of a schweiz sample JPEG (cycled).  Thumbnail
+    PNGs are pre-built into ``base/thumbs`` so the UI renders real images.
+    """
+    base = tmp_path_factory.mktemp("timeline_wrap_test")
+    db_path = base / "timeline.db"
+    img_dir = base / "images"
+    thumbs_dir = base / "thumbs"
+    img_dir.mkdir()
+    thumbs_dir.mkdir()
+
+    # Resize template images once; cycle through them for the 65 years.
+    templates: list[Image.Image] = []
+    for src in _SAMPLE_JPGS:
+        t = Image.open(src)
+        t.thumbnail((600, 450), Image.LANCZOS)
+        templates.append(t)
+
+    repo = ImageIndexRepository(db_path, key="")
+    for i, year in enumerate(_YEARS):
+        ts = datetime.datetime(
+            year, 6, 15, 12, 0, 0, tzinfo=datetime.timezone.utc
+        ).timestamp()
+        img_path = img_dir / f"year_{year}.jpg"
+        tpl = templates[i % len(templates)]
+        tpl.convert("RGB").save(str(img_path), "JPEG", quality=75)
+
+        stat = img_path.stat()
+        # Pre-build thumbnail PNG so ThumbnailImageProvider can serve it.
+        thumb_name = thumb_cache_name_from_stamp(str(img_path), stat.st_mtime, stat.st_size)
+        thumb = tpl.copy()
+        thumb.thumbnail(_THUMB_SIZE, Image.LANCZOS)
+        thumb.convert("RGBA").save(str(thumbs_dir / thumb_name), "PNG")
+
+        repo.upsert_image(
+            str(img_path),
+            img_path.name,
+            stat.st_mtime,
+            stat.st_size,
+            {},
+            f"photo from {year}",
+            captured_at=ts,
+        )
+    repo.commit()
+    repo.close()
+    return db_path, base
+
+
+@pytest.fixture
+def timeline_window(
+    qtbot: QtBot,
+    timeline_db: tuple[Path, Path],
+) -> Generator[tuple[QQuickItem, AppController, QQmlApplicationEngine], None, None]:
+    """Full QML window loaded with timeline data; yields (root, controller, engine)."""
+    db_path, base = timeline_db
+
+    thumb_provider = ThumbnailImageProvider()
+    search_model = SearchListModel(cache_dir=base / "thumbs")
+    exif_model = ExifListModel()
+    folder_model = FolderListModel()
+    settings_model = SettingsModel(base / "settings.json")
+    filter_proxy = CheckedFilterProxyModel()
+    filter_proxy.setSourceModel(search_model)
+    controller = AppController(
+        db_path, search_model, exif_model, folder_model,
+        thumb_provider=thumb_provider,
+    )
+    controller.set_filter_proxy(filter_proxy)
+
+    engine = QQmlApplicationEngine()
+    engine.addImageProvider("thumb", thumb_provider)
+    engine.addImageProvider("preview", PreviewImageProvider())
+    engine.addImageProvider("raw", RawImageProvider())
+    ctx = engine.rootContext()
+    ctx.setContextProperty("controller", controller)
+    ctx.setContextProperty("searchModel", search_model)
+    ctx.setContextProperty("filteredSearchModel", filter_proxy)
+    ctx.setContextProperty("exifModel", exif_model)
+    ctx.setContextProperty("folderListModel", folder_model)
+    ctx.setContextProperty("settingsModel", settings_model)
+    ctx.setContextProperty("thirdPartyLicensesHtml", "")
+    ctx.setContextProperty("userManualUrl", "")
+    engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+    qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+    root = engine.rootObjects()[0]
+
+    with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+        controller.unlock("")
+
+    with qtbot.waitSignal(controller.yearCountsChanged, timeout=5000):
+        controller.search("")
+
+    # Allow QML reactive bindings to propagate.
+    qtbot.wait(400)
+
+    yield root, controller, engine
+
+    controller.close()
+    engine.deleteLater()
+    qtbot.wait(200)
+
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _save_screenshot(window: QQuickItem, name: str) -> None:
+    """Grab the window and write it to the OS temp directory; non-fatal."""
+    import tempfile
+
+    try:
+        out = Path(tempfile.gettempdir()) / name
+        img = window.grabWindow()
+        img.save(str(out))
+        print(f"\nScreenshot saved to: {out}")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+
+class TestTimelineFilterWrap:
+    """Timeline Filter histogram must show all year bars without horizontal clipping."""
+
+    def test_timeline_filter_year_bars_visible_without_horizontal_clipping(
+        self,
+        qtbot: QtBot,
+        timeline_window: tuple[QQuickItem, AppController, QQmlApplicationEngine],
+    ) -> None:
+        # Arrange
+        root, _controller, _engine = timeline_window
+
+        date_filter_row = root.findChild(QQuickItem, "dateFilterRow")
+        assert date_filter_row is not None, (
+            "objectName: 'dateFilterRow' is missing from the Rectangle in Main.qml"
+        )
+
+        # Assert — the date filter panel must be visible (year data loaded).
+        qtbot.waitUntil(
+            lambda: date_filter_row.property("visible") is True,
+            timeout=3000,
+        )
+
+        hist_flickable = root.findChild(QQuickItem, "histFlickable")
+
+        if hist_flickable is not None:
+            # Wait for Qt Quick to compute the Row's implicitWidth so that the
+            # Flickable's contentWidth is non-zero before we assert on it.
+            qtbot.waitUntil(
+                lambda: hist_flickable.property("contentWidth") > _LAYOUT_READY_MIN_CONTENT_PX,
+                timeout=3000,
+            )
+
+        # Act — wait for thumbnails to render, then capture the current state.
+        qtbot.wait(800)
+        _save_screenshot(root, "timeline_clip_bug.png")
+
+        if hist_flickable is not None:
+            # Current (unfixed) layout: Flickable must not clip bars.
+            content_w: float = hist_flickable.property("contentWidth")
+            visible_w: float = hist_flickable.property("width")
+            assert content_w <= visible_w, (
+                f"Timeline Filter clips year bars: contentWidth ({content_w:.0f} px) "
+                f"> visible width ({visible_w:.0f} px).  "
+                f"{len(_YEARS)} year bars × {_BAR_STEP_PX} px/bar = "
+                f"{len(_YEARS) * _BAR_STEP_PX} px total — bars beyond the visible "
+                f"edge are silently hidden.  Replace the Flickable+Row with a "
+                f"wrapping Flow so that all bars remain reachable."
+            )
+        else:
+            # Fixed layout (Flow): the panel must grow to accommodate wrapped rows.
+            panel_h: float = date_filter_row.property("height")
+            assert panel_h > _ORIGINAL_SINGLE_ROW_HEIGHT, (
+                f"dateFilterRow height ({panel_h:.0f} px) is not taller than the "
+                f"original single-row height ({_ORIGINAL_SINGLE_ROW_HEIGHT} px).  "
+                f"With {len(_YEARS)} year bars the Flow must wrap to multiple rows."
+            )


### PR DESCRIPTION
## Summary

Fixes #9 — year bars in the timeline filter histogram were silently clipped when the total width of all bars exceeded the available container width.

## Changes

- **Replace Flickable+Row with Flow** so bars wrap to additional rows instead of overflowing/clipping
- **Bind dateFilterRow.implicitHeight** to histFlow.implicitHeight + 8 so the strip grows dynamically
- **Fix bar delegate height** to a constant 60 px (previously derived from the container, causing a circular binding)
- **Remove FloatingBadge 'TAKEN' label** — it consumed horizontal space unnecessarily
- **Add hover tooltip** to dateFilterRow via a non-blocking MouseArea (cceptedButtons: Qt.NoButton) so the strip's purpose is discoverable without taking up space

## Tests

Added 	ests/ui/test_timeline_filter_wrap.py — an E2E test that seeds 65 years of data (1960–2024) and asserts the strip height exceeds 68 px (i.e. wraps), which fails with the old fixed-height Flickable layout.