### PR TITLE
fix: Browse jump skips images beyond first page

### DIFF
--- a/src/exif_turbo/models/search_result.py
+++ b/src/exif_turbo/models/search_result.py
@@ -10,3 +10,4 @@ class SearchResult:
     metadata_json: str
     size: int = 0
     mtime: float = 0.0
+    image_id: int = 0

--- a/src/exif_turbo/ui/models/search_list_model.py
+++ b/src/exif_turbo/ui/models/search_list_model.py
@@ -60,6 +60,7 @@ class SearchListModel(QAbstractListModel):
     DateRole = Qt.UserRole + 8
     DimsRole = Qt.UserRole + 9
     LensRole = Qt.UserRole + 10
+    ImageIdRole = Qt.UserRole + 11
 
     def __init__(self, cache_dir: Path) -> None:
         super().__init__()
@@ -91,6 +92,7 @@ class SearchListModel(QAbstractListModel):
             self.DateRole: b"date",
             self.DimsRole: b"dims",
             self.LensRole: b"lens",
+            self.ImageIdRole: b"imageId",
         }
 
     def _scan_cache_dir(self) -> set[str]:
@@ -173,6 +175,8 @@ class SearchListModel(QAbstractListModel):
             return item.size
         if role == self.CheckedRole:
             return item.path in self._checked
+        if role == self.ImageIdRole:
+            return item.image_id
         if role in (self.CameraRole, self.DateRole, self.DimsRole, self.LensRole):
             if self._display_cache[row] is None:
                 self._display_cache[row] = _extract_display(item.metadata_json)
@@ -228,6 +232,18 @@ class SearchListModel(QAbstractListModel):
     def get_path(self, row: int) -> str | None:
         if 0 <= row < len(self._rows):
             return self._rows[row].path
+
+    def get_image_id(self, row: int) -> int | None:
+        if 0 <= row < len(self._rows):
+            return self._rows[row].image_id
+        return None
+
+    def find_row_by_id(self, image_id: int) -> int:
+        """Return the source row index for *image_id*, or -1 if not loaded."""
+        for i, row in enumerate(self._rows):
+            if row.image_id == image_id:
+                return i
+        return -1
         return None
 
     def get_stamp(self, row: int) -> tuple[float, int] | None:

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -172,10 +172,10 @@ ApplicationWindow {
         // Called after every search finishes (Browse folder load or Search tab restore).
         function onLoadedResultsChanged() {
             // Browse tab: jump to the pending target image once folder results are loaded.
-            if (mainTabBar.currentIndex === 1 && root._pendingBrowseTarget !== "") {
-                var target = root._pendingBrowseTarget
-                root._pendingBrowseTarget = ""
-                var proxyRow = controller.selectResultByPath(target)
+            if (mainTabBar.currentIndex === 1 && root._pendingBrowseTargetId !== -1) {
+                var target = root._pendingBrowseTargetId
+                root._pendingBrowseTargetId = -1
+                var proxyRow = controller.selectResultById(target)
                 if (proxyRow >= 0) {
                     // Use positionViewAtIndex (delegate-height-agnostic) and a
                     // double Qt.callLater to run after the ListView's own layout
@@ -341,8 +341,8 @@ ApplicationWindow {
     // ── Browse / Search cross-tab navigation state ─────────────────────────
     // contentY of resultsList captured when entering Browse; -1 = nothing saved
     property real   _savedSearchScrollY:    -1.0
-    // Full image path to locate and scroll to once Browse results finish loading
-    property string _pendingBrowseTarget:   ""
+    // DB image id to locate and scroll to once Browse results finish loading; -1 = none
+    property int    _pendingBrowseTargetId: -1
     // One-shot flag: restore resultsList position after the next search load
     property bool   _restoreSearchPosition: false
 
@@ -937,7 +937,7 @@ ApplicationWindow {
             } else if (currentIndex === 0) {
                 // Returning to Search: restore the snapshot, repopulate searchField,
                 // and request a one-shot scroll restore once results have loaded.
-                root._pendingBrowseTarget = ""
+                root._pendingBrowseTargetId = -1
                 root._restoreSearchPosition = true
                 var savedQuery = controller.leaveBrowseTab()
                 searchField.text = savedQuery
@@ -1795,13 +1795,13 @@ ApplicationWindow {
                                     hoverEnabled:  true
                                     cursorShape:   Qt.PointingHandCursor
                                     onClicked: {
-                                        var targetPath = model.path
-                                        var folder = targetPath.replace(/[/\\][^/\\]*$/, "")
+                                        var targetId = model.imageId
+                                        var folder = model.path.replace(/[/\\][^/\\]*$/, "")
                                         // Select this card BEFORE switching tabs so enterBrowseTab
                                         // snapshots the row of this image (not the previously
                                         // selected card) for restoration on return.
                                         controller.selectResult(index)
-                                        root._pendingBrowseTarget = targetPath
+                                        root._pendingBrowseTargetId = targetId
                                         mainTabBar.currentIndex = 1
                                         controller.browseFolder(folder)
                                     }

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -1803,7 +1803,7 @@ ApplicationWindow {
                                         controller.selectResult(index)
                                         root._pendingBrowseTargetId = targetId
                                         mainTabBar.currentIndex = 1
-                                        controller.browseFolder(folder)
+                                        controller.browseFolder(folder, targetId)
                                     }
                                 }
                             }

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -196,8 +196,9 @@ class AppController(QObject):
         # `None` means no snapshot is currently held.
         self._search_state_snapshot: dict | None = None
         # When restoring from Browse → Search, load enough pages of results so
-        # the previously-selected row is included in the (proxy) model.
-        self._pending_restore_target_row: int | None = None
+        # the previously-selected image (identified by its DB id) is included in
+        # the model.  0 means no pending restore.
+        self._pending_restore_image_id: int = 0
         self._folder_tree: str = "[]"
         self._folder_tree_dirty: bool = False
         self._pending_preview_path: str = ""
@@ -1185,7 +1186,7 @@ class AppController(QObject):
             "ext_filter": self._ext_filter,
             "date_from": self._date_from,
             "date_to": self._date_to,
-            "current_result_row": self._current_result_row,
+            "current_image_id": self._search_model.get_image_id(self._current_result_row) or 0,
         }
         self._query_text = ""
         if self._search_folder_filters:
@@ -1221,11 +1222,9 @@ class AppController(QObject):
             self._run_search()
             return ""
         self._query_text = snapshot["query_text"]
-        self._current_result_row = snapshot.get("current_result_row", 0)
-        # Remember the target row so _on_search_finished can load enough
-        # pages to make it reachable in the model/proxy before scroll-restore.
-        if self._current_result_row >= 0:
-            self._pending_restore_target_row = self._current_result_row
+        image_id = snapshot.get("current_image_id", 0)
+        if image_id:
+            self._pending_restore_image_id = image_id
         restored_search_folders = snapshot["search_folder_filters"]
         if restored_search_folders != self._search_folder_filters:
             self._search_folder_filters = restored_search_folders
@@ -1354,7 +1353,7 @@ class AppController(QObject):
             return
         self._set_search_error("")
         results = [
-            SearchResult(path=r[1], filename=r[2], metadata_json=r[3], size=r[4], mtime=r[5])
+            SearchResult(image_id=r[0], path=r[1], filename=r[2], metadata_json=r[3], size=r[4], mtime=r[5])
             for r in rows
         ]
         # Block loadMore for the duration of the model reset.  Without this
@@ -1375,16 +1374,14 @@ class AppController(QObject):
         self._total_results = total
         self._loaded_results = len(results)
         # Returning from Browse: synchronously load enough additional pages
-        # so the previously-selected row (and its saved scroll position) is
-        # reachable in the model before the QML scroll-restore handler runs.
-        if (
-            self._pending_restore_target_row is not None
-            and self._repo is not None
-        ):
-            target = self._pending_restore_target_row
-            self._pending_restore_target_row = None
+        # so the previously-selected image is reachable in the model before
+        # the QML scroll-restore handler runs.  Uses the DB image id so a
+        # concurrent indexer run that changes row counts doesn't land on the
+        # wrong image.
+        if self._pending_restore_image_id and self._repo is not None:
+            target_id = self._pending_restore_image_id
             while (
-                self._loaded_results <= target
+                self._search_model.find_row_by_id(target_id) < 0
                 and self._loaded_results < self._total_results
             ):
                 more_rows = self._repo.search_images(
@@ -1403,7 +1400,7 @@ class AppController(QObject):
                     break
                 more_results = [
                     SearchResult(
-                        path=r[1], filename=r[2], metadata_json=r[3],
+                        image_id=r[0], path=r[1], filename=r[2], metadata_json=r[3],
                         size=r[4], mtime=r[5],
                     )
                     for r in more_rows
@@ -1419,12 +1416,19 @@ class AppController(QObject):
         self._apply_format_counts(format_counts)
         self._load_year_counts()
         if self._loaded_results > 0:
-            row = (
-                self._current_result_row
-                if 0 <= self._current_result_row < self._loaded_results
-                else 0
-            )
-            self._select_source_row(row)
+            if self._pending_restore_image_id:
+                restore_id = self._pending_restore_image_id
+                self._pending_restore_image_id = 0
+                if self.selectResultById(restore_id) < 0:
+                    # Image was deleted from the index while browsing; fall back.
+                    self._select_source_row(0)
+            else:
+                row = (
+                    self._current_result_row
+                    if 0 <= self._current_result_row < self._loaded_results
+                    else 0
+                )
+                self._select_source_row(row)
         else:
             self._clear_details()
 
@@ -1517,7 +1521,7 @@ class AppController(QObject):
             date_to=self._date_to,
         )
         results = [
-            SearchResult(path=r[1], filename=r[2], metadata_json=r[3], size=r[4], mtime=r[5])
+            SearchResult(image_id=r[0], path=r[1], filename=r[2], metadata_json=r[3], size=r[4], mtime=r[5])
             for r in rows
         ]
         self._search_model.append_rows(results)
@@ -1531,13 +1535,30 @@ class AppController(QObject):
         row = self._filter_proxy.source_row_for(proxy_row) if self._filter_proxy else proxy_row
         self._select_source_row(row)
 
+    @Slot(int, result=int)
+    def selectResultById(self, image_id: int) -> int:
+        """Find the image with *image_id* in the current results, select it,
+        and return its proxy row (or -1 if not found).
+
+        Used by QML to scroll Browse tab to a specific image after
+        navigating from a Search result card.
+        """
+        n = self._search_model.rowCount()
+        for source_row in range(n):
+            if self._search_model.get_image_id(source_row) == image_id:
+                self._select_source_row(source_row)
+                pr = (
+                    self._filter_proxy.proxy_row_for(source_row)
+                    if self._filter_proxy
+                    else source_row
+                )
+                return pr
+        return -1
+
     @Slot(str, result=int)
     def selectResultByPath(self, path: str) -> int:
         """Find the image at *path* in the current results, select it, and
         return its proxy row (or -1 if not found).
-
-        Used by QML to scroll Browse tab to a specific image after
-        navigating from a Search result card.
         """
         n = self._search_model.rowCount()
         for source_row in range(n):

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -199,6 +199,9 @@ class AppController(QObject):
         # the previously-selected image (identified by its DB id) is included in
         # the model.  0 means no pending restore.
         self._pending_restore_image_id: int = 0
+        # When jumping from Search → Browse, preload pages until the target
+        # image id is in the model.  0 means no pending jump.
+        self._pending_browse_jump_id: int = 0
         self._folder_tree: str = "[]"
         self._folder_tree_dirty: bool = False
         self._pending_preview_path: str = ""
@@ -1151,17 +1154,24 @@ class AppController(QObject):
         self._run_search()
 
     @Slot(str)
-    def browseFolder(self, path: str) -> None:
+    @Slot(str, int)
+    def browseFolder(self, path: str, target_id: int = 0) -> None:
         """Navigate to a folder in the Browse tab.
 
         Clears any active search query so the full folder contents are shown.
         Clicking the already-selected folder clears the filter.
+
+        *target_id* is the DB primary key of the image to pre-scroll to once
+        the folder results have loaded (passed from the "Browse →" button in
+        QML).  0 means no pre-scroll target.
         """
         if self._folder_filter == path:
             self._folder_filter = ""
+            self._pending_browse_jump_id = 0
         else:
             self._query_text = ""
             self._folder_filter = path
+            self._pending_browse_jump_id = target_id
         self.folderFilterChanged.emit()
         self._run_search()
 
@@ -1213,6 +1223,9 @@ class AppController(QObject):
         """
         snapshot = self._search_state_snapshot
         self._search_state_snapshot = None
+        # Discard any in-flight forward Browse-jump target — it belongs to
+        # the Browse session we are now leaving.
+        self._pending_browse_jump_id = 0
         # Always drop the Browse-tab folder filter when returning.
         if self._folder_filter:
             self._folder_filter = ""
@@ -1382,6 +1395,38 @@ class AppController(QObject):
             target_id = self._pending_restore_image_id
             while (
                 self._search_model.find_row_by_id(target_id) < 0
+                and self._loaded_results < self._total_results
+            ):
+                more_rows = self._repo.search_images(
+                    self._query_text,
+                    _PAGE_SIZE,
+                    self._loaded_results,
+                    sort_by=self._sort_by,
+                    ext_filter=self._ext_filter,
+                    path_filter=self._current_path_filter(),
+                    restrict_to_enabled_folders=(self._folder_repo is not None),
+                    marked_only=self._checked_only_filter_active,
+                    date_from=self._date_from,
+                    date_to=self._date_to,
+                )
+                if not more_rows:
+                    break
+                more_results = [
+                    SearchResult(
+                        image_id=r[0], path=r[1], filename=r[2], metadata_json=r[3],
+                        size=r[4], mtime=r[5],
+                    )
+                    for r in more_rows
+                ]
+                self._search_model.append_rows(more_results)
+                self._loaded_results += len(more_results)
+        # Forward Browse jump (Search → Browse): preload pages until the target
+        # image is in the model so QML's selectResultById call succeeds.
+        if self._pending_browse_jump_id and self._repo is not None:
+            jump_id = self._pending_browse_jump_id
+            self._pending_browse_jump_id = 0
+            while (
+                self._search_model.find_row_by_id(jump_id) < 0
                 and self._loaded_results < self._total_results
             ):
                 more_rows = self._repo.search_images(

--- a/tests/ui/test_browse_navigation.py
+++ b/tests/ui/test_browse_navigation.py
@@ -297,6 +297,67 @@ class TestBrowseNavigation:
         # Assert — the correct image (by id) is selected, not the shifted row.
         assert search_model.get_path(controller.currentResultRow) == selected_path
 
+    def test_browseFolder_with_target_id_preloads_beyond_first_page(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+    ) -> None:
+        """browseFolder(folder, target_id) must preload pages until the
+        target image is in the model, even when it falls beyond the first
+        page (page size = 50).  Regression test for the bug where
+        selectResultById always failed because the folder had >50 images.
+        """
+        from exif_turbo.ui.models.exif_list_model import ExifListModel
+        from exif_turbo.ui.models.folder_list_model import FolderListModel
+        from exif_turbo.ui.models.settings_model import SettingsModel
+
+        folder = tmp_path / "large_folder"
+        folder.mkdir()
+
+        repo = ImageIndexRepository(tmp_path / "large.db", key="")
+        # Index 55 images so the last one is on page 2 (page size = 50).
+        for i in range(55):
+            fname = f"img_{i:04d}.jpg"
+            img_path = folder / fname
+            Image.new("RGB", (8, 8)).save(str(img_path), format="JPEG")
+            stat = img_path.stat()
+            repo.upsert_image(str(img_path), fname, stat.st_mtime, stat.st_size, {}, "")
+        repo.commit()
+
+        # The last image by filename sort order will be on page 2.
+        target_fname = "img_0054.jpg"
+        target_path = str(folder / target_fname)
+        repo_r = ImageIndexRepository(tmp_path / "large.db", key="")
+        rows = repo_r.search_images("", 200, 0, sort_by="filename")
+        target_id = next(r[0] for r in rows if r[2] == target_fname)
+        repo_r.close()
+        repo.close()
+
+        search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+        controller = AppController(
+            tmp_path / "large.db", search_model,
+            ExifListModel(), FolderListModel(),
+            SettingsModel(tmp_path / "settings.json"),
+        )
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.unlock("")
+        qtbot.wait(_PAUSE_MS)
+
+        controller.enterBrowseTab("")
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.browseFolder(str(folder), target_id)
+        qtbot.wait(_PAUSE_MS)
+
+        # Act — QML would call this once onLoadedResultsChanged fires.
+        proxy_row = controller.selectResultById(target_id)
+
+        # Assert — preloading brought the target into the model.
+        assert proxy_row >= 0
+        assert search_model.get_path(controller.currentResultRow) == target_path
+
+        controller.close()
+        qtbot.wait(100)
+
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/tests/ui/test_browse_navigation.py
+++ b/tests/ui/test_browse_navigation.py
@@ -1,10 +1,10 @@
 """E2E tests for the "Browse →" / "← Search" cross-tab navigation feature.
 
 Covers:
-  * selectResultByPath — finds an image by path, selects it, returns proxy row
-  * selectResultByPath with an unknown path — returns -1
+  * selectResultById — finds an image by integer id, selects it, returns proxy row
+  * selectResultById with an unknown id — returns -1
   * Full flow: search results → enterBrowseTab + browseFolder →
-    selectResultByPath locates and selects the correct image in Browse
+    selectResultById locates and selects the correct image in Browse
   * Returning to Search after Browse navigation preserves the previously
     selected search result row
 
@@ -90,28 +90,28 @@ def controller_with_images(
     qtbot.wait(100)
 
 
-# ── selectResultByPath ────────────────────────────────────────────────────────
+# ── selectResultById ──────────────────────────────────────────────────────────
 
 
-class TestSelectResultByPath:
-    def test_selectResultByPath_known_path_returns_proxy_row(
+class TestSelectResultById:
+    def test_selectResultById_known_id_returns_proxy_row(
         self,
         qtbot: QtBot,
         controller_with_images: tuple[AppController, SearchListModel, Path, Path],
     ) -> None:
-        # Arrange — all 5 images are loaded; pick any path from the model.
+        # Arrange — all 5 images are loaded; pick any id from the model.
         controller, search_model, _, _ = controller_with_images
         target_source_row = 2
-        target_path = search_model.get_path(target_source_row)
-        assert target_path is not None
+        target_id = search_model.get_image_id(target_source_row)
+        assert target_id is not None
 
         # Act
-        proxy_row = controller.selectResultByPath(target_path)
+        proxy_row = controller.selectResultById(target_id)
 
         # Assert — a valid (≥ 0) proxy row is returned
         assert proxy_row >= 0
 
-    def test_selectResultByPath_unknown_path_returns_minus_one(
+    def test_selectResultById_unknown_id_returns_minus_one(
         self,
         qtbot: QtBot,
         controller_with_images: tuple[AppController, SearchListModel, Path, Path],
@@ -120,12 +120,12 @@ class TestSelectResultByPath:
         controller, _, _, _ = controller_with_images
 
         # Act
-        result = controller.selectResultByPath("/no/such/image.jpg")
+        result = controller.selectResultById(-999)
 
         # Assert
         assert result == -1
 
-    def test_selectResultByPath_selects_matching_image(
+    def test_selectResultById_selects_matching_image(
         self,
         qtbot: QtBot,
         controller_with_images: tuple[AppController, SearchListModel, Path, Path],
@@ -133,28 +133,29 @@ class TestSelectResultByPath:
         # Arrange — pick the last image in the model (non-trivial row index).
         controller, search_model, _, _ = controller_with_images
         last_row = search_model.rowCount() - 1
+        target_id = search_model.get_image_id(last_row)
         target_path = search_model.get_path(last_row)
-        assert target_path is not None
+        assert target_id is not None
 
         # Act
-        controller.selectResultByPath(target_path)
+        controller.selectResultById(target_id)
         qtbot.wait(_PAUSE_MS)
 
         # Assert — the controller's selected source row matches the target.
         assert search_model.get_path(controller.currentResultRow) == target_path
 
-    def test_selectResultByPath_proxy_row_matches_currentProxyResultRow(
+    def test_selectResultById_proxy_row_matches_currentProxyResultRow(
         self,
         qtbot: QtBot,
         controller_with_images: tuple[AppController, SearchListModel, Path, Path],
     ) -> None:
         # Arrange
         controller, search_model, _, _ = controller_with_images
-        target_path = search_model.get_path(1)
-        assert target_path is not None
+        target_id = search_model.get_image_id(1)
+        assert target_id is not None
 
         # Act
-        returned_proxy_row = controller.selectResultByPath(target_path)
+        returned_proxy_row = controller.selectResultById(target_id)
         qtbot.wait(_PAUSE_MS)
 
         # Assert — returned value matches the property exposed to QML.
@@ -165,15 +166,22 @@ class TestSelectResultByPath:
 
 
 class TestBrowseNavigation:
-    def test_selectResultByPath_after_browseFolder_selects_image_in_browse(
+    def test_selectResultById_after_browseFolder_selects_image_in_browse(
         self,
         qtbot: QtBot,
         controller_with_images: tuple[AppController, SearchListModel, Path, Path],
     ) -> None:
-        # Arrange — simulate the "Browse →" button: save the path of a
-        # folder_b image, enter Browse, load that folder.
-        controller, _, _, folder_b = controller_with_images
+        # Arrange — simulate the "Browse →" button: save the id of a
+        # folder_b image from Search results, enter Browse, load that folder.
+        controller, search_model, _, folder_b = controller_with_images
         target_path = str(folder_b / "delta.jpg")
+        # Find the id in the current Search results (all images are loaded).
+        target_id: int | None = None
+        for i in range(search_model.rowCount()):
+            if search_model.get_path(i) == target_path:
+                target_id = search_model.get_image_id(i)
+                break
+        assert target_id is not None
 
         controller.enterBrowseTab("")
         with qtbot.waitSignal(controller.totalResultsChanged, timeout=3000):
@@ -181,21 +189,27 @@ class TestBrowseNavigation:
         qtbot.wait(_PAUSE_MS)
 
         # Act — QML would call this once browseImageList.countChanged fires.
-        proxy_row = controller.selectResultByPath(target_path)
+        proxy_row = controller.selectResultById(target_id)
         qtbot.wait(_PAUSE_MS)
 
         # Assert — the image is found and selected.
         assert proxy_row >= 0
         assert search_model_path(controller) == target_path
 
-    def test_selectResultByPath_image_not_in_current_browse_folder_returns_minus_one(
+    def test_selectResultById_image_not_in_current_browse_folder_returns_minus_one(
         self,
         qtbot: QtBot,
         controller_with_images: tuple[AppController, SearchListModel, Path, Path],
     ) -> None:
-        # Arrange — browse folder_b, but look for a folder_a image.
-        controller, _, folder_a, folder_b = controller_with_images
-        path_from_other_folder = str(folder_a / "alpha.jpg")
+        # Arrange — browse folder_b, but look for a folder_a image id.
+        controller, search_model, folder_a, folder_b = controller_with_images
+        alpha_path = str(folder_a / "alpha.jpg")
+        alpha_id: int | None = None
+        for i in range(search_model.rowCount()):
+            if search_model.get_path(i) == alpha_path:
+                alpha_id = search_model.get_image_id(i)
+                break
+        assert alpha_id is not None
 
         controller.enterBrowseTab("")
         with qtbot.waitSignal(controller.totalResultsChanged, timeout=3000):
@@ -203,7 +217,7 @@ class TestBrowseNavigation:
         qtbot.wait(_PAUSE_MS)
 
         # Act
-        result = controller.selectResultByPath(path_from_other_folder)
+        result = controller.selectResultById(alpha_id)
 
         # Assert — image is not in the Browse results, so -1 is returned.
         assert result == -1
@@ -227,7 +241,14 @@ class TestBrowseNavigation:
             controller.browseFolder(str(folder_b))
         qtbot.wait(_PAUSE_MS)
         # Select a different image while in Browse — delta.jpg is typically row 0.
-        controller.selectResultByPath(str(folder_b / "delta.jpg"))
+        delta_path = str(folder_b / "delta.jpg")
+        delta_id: int | None = None
+        for i in range(search_model.rowCount()):
+            if search_model.get_path(i) == delta_path:
+                delta_id = search_model.get_image_id(i)
+                break
+        assert delta_id is not None
+        controller.selectResultById(delta_id)
         qtbot.wait(_PAUSE_MS)
 
         # Act — return to Search tab.
@@ -240,6 +261,41 @@ class TestBrowseNavigation:
         assert controller.totalResults == len(_IMAGES)
         assert controller.currentResultRow == search_row_before
         assert search_model.get_path(controller.currentResultRow) == search_path_before
+
+    def test_leave_browse_tab_restores_correct_image_after_index_insert(
+        self,
+        qtbot: QtBot,
+        controller_with_images: tuple[AppController, SearchListModel, Path, Path],
+    ) -> None:
+        # Arrange — select a non-zero row and record its image id.
+        controller, search_model, folder_a, folder_b = controller_with_images
+        controller.selectResult(2)
+        qtbot.wait(_PAUSE_MS)
+        selected_id = search_model.get_image_id(controller.currentResultRow)
+        selected_path = search_model.get_path(controller.currentResultRow)
+        assert selected_id is not None
+
+        controller.enterBrowseTab("")
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=3000):
+            controller.browseFolder(str(folder_b))
+        qtbot.wait(_PAUSE_MS)
+
+        # Simulate the indexer inserting a new image that sorts before the
+        # selected one, which would shift the saved row number by 1.
+        new_img = folder_a / "aardvark.jpg"
+        Image.new("RGB", (32, 32)).save(str(new_img), format="JPEG")
+        stat = new_img.stat()
+        repo = controller._repo  # type: ignore[attr-defined]
+        repo.upsert_image(str(new_img), "aardvark.jpg", stat.st_mtime, stat.st_size, {}, "")
+        repo.commit()
+
+        # Act — return to Search tab; the row number is now stale.
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=3000):
+            controller.leaveBrowseTab()
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert — the correct image (by id) is selected, not the shifted row.
+        assert search_model.get_path(controller.currentResultRow) == selected_path
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

When clicking the **Browse →** button on a Search result card, the Browse tab would open the correct folder but never scroll to or highlight the target image.

## Root Cause

The folder had more than 50 images (the page size). The QML \onLoadedResultsChanged\ handler consumed \_pendingBrowseTargetId\ as soon as the **first page** of Browse results loaded, but the target image was on a later page — so \selectResultById\ returned \-1\ every time.

## Fix

### app_controller.py\
- browseFolder(path, target_id=0)\ — added \@Slot(str, int)\ overload; stores \	arget_id\ in \_pending_browse_jump_id\.
- \_on_search_finished\ — new page-preloading loop (mirrors the existing \_pending_restore_image_id\ loop for the Browse→Search direction) loads additional pages synchronously until \ind_row_by_id(jump_id)\ succeeds or all rows are exhausted, **before** \loadedResultsChanged\ is emitted.
- \leaveBrowseTab\ — clears \_pending_browse_jump_id\ so a stale target cannot bleed into the Search-restore search.

### \Main.qml\
- Browse button calls \controller.browseFolder(folder, targetId)\ (passes target id as second argument).

## Tests

All 224 existing tests pass. New regression test added:
\	est_browseFolder_with_target_id_preloads_beyond_first_page\ — indexes 55 images (> page size 50), verifies the target image on page 2 is found and selected after the Browse jump.