### PR TITLE
Add AI search support and polish Browse navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,7 @@ coverage.xml
 *.py.cover
 .hypothesis/
 .pytest_cache/
+.pytest-*.xml
 cover/
 
 # Translations
@@ -226,3 +227,5 @@ data/index.db
 data/**
 tests/.DS_Store
 .DS_Store
+.tmp*
+tmp_diag_*/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
   "cryptography>=42.0",
   "pyvips>=2.2",
   "pyvips-binary>=2.2",
+  "faiss-cpu>=1.7",
+  "open-clip-torch>=2.24",
 ]
 
 [project.scripts]

--- a/src/exif_turbo/config.py
+++ b/src/exif_turbo/config.py
@@ -32,6 +32,16 @@ def thumb_cache_dir(db_path: Path) -> Path:
     return Path.home() / ".exif-turbo" / "data" / db_path.stem / "thumbs"
 
 
+def ai_index_path(db_path: Path) -> Path:
+    """Path to the FAISS vector index file for the given database."""
+    return Path.home() / ".exif-turbo" / "data" / db_path.stem / "ai_index.faiss"
+
+
+def ai_id_map_path(db_path: Path) -> Path:
+    """Path to the JSON id-map (FAISS integer ID → image path) for the given database."""
+    return Path.home() / ".exif-turbo" / "data" / db_path.stem / "ai_id_map.json"
+
+
 def settings_path(db_path: Path) -> Path:
     """Per-database settings file.
 

--- a/src/exif_turbo/data/ai_vector_repository.py
+++ b/src/exif_turbo/data/ai_vector_repository.py
@@ -1,0 +1,177 @@
+"""Persist CLIP embeddings in a FAISS flat inner-product index.
+
+Layout on disk (both files live in the same directory as the SQLite DB):
+  ai_index.faiss   — raw FAISS index (IndexFlatIP, dim=512)
+  ai_id_map.json   — {"0": "/path/img.jpg", "1": ...}  (FAISS row id → path)
+
+All vectors stored here are L2-normalised so inner-product search equals
+cosine similarity.  Sequential integer IDs (0, 1, 2, …) are assigned by
+IndexFlatIP.add() and are the keys in the JSON id-map.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Dict, List
+
+import numpy as np
+
+_log = logging.getLogger(__name__)
+
+_DIM = 512  # ViT-B/32 CLIP embedding dimension
+
+
+class AiVectorRepository:
+    """Manages a single FAISS flat index plus an in-memory id→path mapping."""
+
+    def __init__(self, index_path: Path, id_map_path: Path) -> None:
+        self._index_path = index_path
+        self._id_map_path = id_map_path
+        self._faiss = None
+        self._index = None
+        # Maps str(sequential_faiss_id) → absolute image path.
+        self._id_map: Dict[str, str] = {}
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────
+
+    def load(self) -> None:
+        """Load existing index + map from disk; create empty ones if absent."""
+        import faiss  # noqa: PLC0415
+
+        self._faiss = faiss
+        if self._index_path.exists() and self._id_map_path.exists():
+            try:
+                self._index = faiss.read_index(str(self._index_path))
+                raw = json.loads(self._id_map_path.read_text(encoding="utf-8"))
+                self._id_map = {str(k): v for k, v in raw.items()}
+                _log.debug(
+                    "AI index loaded: %d vectors from %s",
+                    self._index.ntotal,
+                    self._index_path,
+                )
+                return
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("AI index corrupt, rebuilding from scratch: %s", exc)
+
+        self._index = faiss.IndexFlatIP(_DIM)
+        self._id_map = {}
+
+    def save(self) -> None:
+        """Persist the current index and id-map to disk."""
+        if self._faiss is None or self._index is None:
+            raise RuntimeError("load() must be called before save()")
+        self._index_path.parent.mkdir(parents=True, exist_ok=True)
+        self._faiss.write_index(self._index, str(self._index_path))
+        self._id_map_path.write_text(
+            json.dumps(self._id_map, ensure_ascii=False, indent=None),
+            encoding="utf-8",
+        )
+
+    # ── Queries ───────────────────────────────────────────────────────────
+
+    def get_indexed_paths(self) -> set[str]:
+        """Return the set of image paths that already have a vector."""
+        return set(self._id_map.values())
+
+    # ── Mutations ─────────────────────────────────────────────────────────
+
+    def add_images(self, embeddings: "np.ndarray", paths: List[str]) -> None:
+        """Append a batch of L2-normalised embeddings with their file paths.
+
+        *embeddings* must be a float32 array of shape (N, 512).
+        *paths* must have length N.  Duplicate paths are not checked here —
+        the caller (AiIndexerService) is responsible for skipping already-
+        indexed images.
+        """
+        if self._index is None:
+            raise RuntimeError("load() must be called before add_images()")
+        n = len(paths)
+        if n == 0:
+            return
+        vecs = np.asarray(embeddings, dtype=np.float32)
+        if vecs.ndim == 1:
+            vecs = vecs.reshape(1, -1)
+        start_id = self._index.ntotal
+        self._index.add(vecs)
+        for i, path in enumerate(paths):
+            self._id_map[str(start_id + i)] = path
+
+    def remove_folder(self, folder_path: str) -> None:
+        """Remove every vector whose path is inside *folder_path*.
+
+        IndexFlatIP does not support in-place deletion, so surviving vectors
+        are reconstructed and a new index is built from scratch.
+        """
+        if self._faiss is None or self._index is None or self._index.ntotal == 0:
+            return
+
+        folder = Path(folder_path)
+        keep_ids: List[int] = [
+            int(k)
+            for k, v in self._id_map.items()
+            if not _is_inside(v, folder)
+        ]
+        if len(keep_ids) == self._index.ntotal:
+            return  # nothing to remove
+
+        if not keep_ids:
+            self._index = self._faiss.IndexFlatIP(_DIM)
+            self._id_map = {}
+            return
+
+        # Reconstruct surviving vectors by their sequential FAISS position.
+        vecs = np.zeros((len(keep_ids), _DIM), dtype=np.float32)
+        for row, old_id in enumerate(keep_ids):
+            self._index.reconstruct(old_id, vecs[row])
+
+        new_index = self._faiss.IndexFlatIP(_DIM)
+        new_index.add(vecs)
+
+        new_map: Dict[str, str] = {
+            str(new_i): self._id_map[str(old_id)]
+            for new_i, old_id in enumerate(keep_ids)
+        }
+        self._index = new_index
+        self._id_map = new_map
+
+    # ── Search ────────────────────────────────────────────────────────────
+
+    def search(
+        self, query_vec: "np.ndarray", top_k: int = 800, threshold: float = 0.20
+    ) -> List[tuple[str, float]]:
+        """Return (path, score) pairs with cosine similarity >= *threshold*.
+
+        Searches the top *top_k* candidates (capped at index size) then
+        discards anything below *threshold*.  Results are sorted descending
+        by score.
+
+        *query_vec* must be a float32 array of shape (512,) or (1, 512).
+        It will be L2-normalised before searching.
+        """
+        if self._index is None or self._index.ntotal == 0:
+            return []
+        vec = np.asarray(query_vec, dtype=np.float32).reshape(1, -1)
+        norm = float(np.linalg.norm(vec))
+        if norm > 0:
+            vec = vec / norm
+        k = min(top_k, self._index.ntotal)
+        scores, ids = self._index.search(vec, k)
+        results: List[tuple[str, float]] = []
+        for score, idx in zip(scores[0], ids[0]):
+            if idx < 0:
+                continue
+            if float(score) < threshold:
+                break  # results are sorted descending — no more hits above threshold
+            path = self._id_map.get(str(int(idx)))
+            if path:
+                results.append((path, float(score)))
+        return results
+
+
+def _is_inside(image_path: str, folder: Path) -> bool:
+    """Return True when *image_path* is the folder itself or a descendant."""
+    try:
+        return Path(image_path).is_relative_to(folder)
+    except ValueError:
+        return False

--- a/src/exif_turbo/data/image_index_repository.py
+++ b/src/exif_turbo/data/image_index_repository.py
@@ -646,6 +646,64 @@ class ImageIndexRepository:
         cur = self.conn.execute(sql, args)
         return int(cur.fetchone()[0])
 
+    def find_image_offset(
+        self,
+        image_id: int,
+        query: str = "",
+        sort_by: str = "",
+        ext_filter: str = "",
+        path_filter: List[str] | None = None,
+        restrict_to_enabled_folders: bool = False,
+        marked_only: bool = False,
+        date_from: int | None = None,
+        date_to: int | None = None,
+    ) -> int | None:
+        """Return the zero-based offset of *image_id* in the filtered result set."""
+        if image_id <= 0:
+            return None
+
+        order = self._resolve_sort(sort_by)
+        ext_clause, ext_args = self._build_ext_clause(ext_filter)
+        path_clause, path_args = self._build_path_clause(path_filter)
+        date_clause, date_args = self._build_date_clause(date_from, date_to)
+        marks_clause = "AND images.marked = 1" if marked_only else ""
+        enabled_clause = self._ENABLED_CLAUSE if restrict_to_enabled_folders else ""
+
+        if query.strip():
+            fts_query = self._sanitize_fts_query(query)
+            order_expr = (
+                f"{order}, images.id ASC"
+                if sort_by
+                else "bm25(images_fts), images.id ASC"
+            )
+            sql = (
+                "SELECT row_offset FROM ("
+                "  SELECT images.id AS image_id, "
+                f"         ROW_NUMBER() OVER (ORDER BY {order_expr}) - 1 AS row_offset "
+                "  FROM images_fts "
+                "  JOIN images ON images_fts.rowid = images.id "
+                f"  WHERE images_fts MATCH ? {ext_clause} {path_clause} {date_clause} {marks_clause} {enabled_clause}"
+                ") ranked "
+                "WHERE image_id = ?"
+            )
+            args = (fts_query,) + ext_args + path_args + date_args + (image_id,)
+        else:
+            sql = (
+                "SELECT row_offset FROM ("
+                "  SELECT images.id AS image_id, "
+                f"         ROW_NUMBER() OVER (ORDER BY {order}, images.id ASC) - 1 AS row_offset "
+                "  FROM images "
+                f"  WHERE 1=1 {ext_clause} {path_clause} {date_clause} {marks_clause} {enabled_clause}"
+                ") ranked "
+                "WHERE image_id = ?"
+            )
+            args = ext_args + path_args + date_args + (image_id,)
+
+        row = self.conn.execute(sql, args).fetchone()
+        if row is None:
+            return None
+        return int(row[0])
+
     def get_matching_paths(
         self,
         query: str,
@@ -1034,6 +1092,30 @@ class ImageIndexRepository:
             for row in rows:
                 result[row[0]] = (row[1], row[2])
         return result
+
+    def get_images_by_paths(
+        self, paths: List[str]
+    ) -> List[Tuple[int, str, str, str, int, float]]:
+        """Fetch full image rows for a list of *paths*, preserving order.
+
+        Returns ``(id, path, filename, metadata_json, size, mtime)`` tuples in
+        the same order as *paths* (FAISS score order), skipping paths not in
+        the DB.  Used by :class:`~exif_turbo.ui.workers.ai_search_worker.AiSearchWorker`
+        to hydrate FAISS hits into the same row format consumed by
+        ``_on_search_finished``.
+        """
+        if not paths:
+            return []
+        placeholders = ",".join("?" * len(paths))
+        cur = self.conn.execute(
+            f"SELECT id, path, filename, metadata_json, size, mtime "
+            f"FROM images WHERE path IN ({placeholders})",
+            paths,
+        )
+        by_path: dict[str, Tuple[int, str, str, str, int, float]] = {}
+        for row in cur.fetchall():
+            by_path[row[1]] = row
+        return [by_path[p] for p in paths if p in by_path]
 
     def _get_pixel_counts_query(
         self, sql: str, params: tuple = ()

--- a/src/exif_turbo/indexing/ai_indexer_service.py
+++ b/src/exif_turbo/indexing/ai_indexer_service.py
@@ -1,0 +1,167 @@
+"""Vectorise images using OpenCLIP (ViT-B/32) and add them to AiVectorRepository.
+
+Usage::
+
+    repo = AiVectorRepository(index_path, id_map_path)
+    repo.load()
+    service = AiIndexerService(repo)
+    indexed, errors = service.build_index(
+        image_paths,
+        on_progress=lambda done, total, path: ...,
+        cancel_check=lambda: False,
+    )
+    repo.save()
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable, List, Optional, Tuple
+
+import numpy as np
+
+from ..data.ai_vector_repository import AiVectorRepository
+
+_log = logging.getLogger(__name__)
+
+_BATCH_SIZE = 32
+_MODEL_NAME = "ViT-B-32"
+_PRETRAINED = "openai"
+
+# Module-level cache — the CLIP model is ~350 MB and takes 10-30 s to load
+# from disk.  Caching it here means every AiIndexerService / AiSearchWorker
+# reuses the same loaded model, so the Python GIL is only held for the long
+# torch.load() call once per app lifetime.
+_cached_model = None
+_cached_preprocess = None
+
+
+class AiIndexerService:
+    """Encode images with CLIP and persist their embeddings."""
+
+    def __init__(self, vector_repo: AiVectorRepository) -> None:
+        self._repo = vector_repo
+        # Model loaded lazily on first call to build_index.
+        self._model = None
+        self._preprocess = None
+        self._tokenizer = None
+
+    # ── Public API ────────────────────────────────────────────────────────
+
+    def build_index(
+        self,
+        image_paths: List[str],
+        on_progress: Optional[Callable[[int, int, str], None]] = None,
+        cancel_check: Optional[Callable[[], bool]] = None,
+    ) -> Tuple[int, int]:
+        """Encode all *image_paths* that are not yet in the repo.
+
+        Returns ``(indexed_count, error_count)``.
+        Calls ``on_progress(done, total, current_path)`` after every batch.
+        Calls ``cancel_check()`` before every batch; stops if it returns True.
+        """
+        already_indexed = self._repo.get_indexed_paths()
+        pending = [p for p in image_paths if p not in already_indexed]
+        total = len(pending)
+        if total == 0:
+            return 0, 0
+
+        self._ensure_model_loaded()
+
+        indexed = 0
+        errors = 0
+
+        for batch_start in range(0, total, _BATCH_SIZE):
+            if cancel_check and cancel_check():
+                break
+
+            batch_paths = pending[batch_start : batch_start + _BATCH_SIZE]
+            embeddings, batch_errors, successful_paths = self._encode_batch(
+                batch_paths
+            )
+            errors += batch_errors
+
+            if successful_paths:
+                self._repo.add_images(embeddings, successful_paths)
+                indexed += len(successful_paths)
+
+            done = min(batch_start + _BATCH_SIZE, total)
+            if on_progress:
+                last_path = batch_paths[-1] if batch_paths else ""
+                on_progress(done, total, last_path)
+
+        return indexed, errors
+
+    def encode_text(self, text: str) -> "np.ndarray":
+        """Return a normalised 512-d float32 vector for *text* (for search)."""
+        import torch  # noqa: PLC0415
+        import open_clip  # noqa: PLC0415
+
+        self._ensure_model_loaded()
+        tokenizer = open_clip.get_tokenizer(_MODEL_NAME)
+        with torch.no_grad():
+            tokens = tokenizer([text])
+            vec = self._model.encode_text(tokens).float().numpy()  # type: ignore[union-attr]
+        vec = vec / np.linalg.norm(vec, axis=1, keepdims=True)
+        return vec.squeeze(0)
+
+    # ── Internals ─────────────────────────────────────────────────────────
+
+    def _ensure_model_loaded(self) -> None:
+        global _cached_model, _cached_preprocess
+        if _cached_model is not None:
+            self._model = _cached_model
+            self._preprocess = _cached_preprocess
+            return
+        import torch  # noqa: PLC0415
+        import open_clip  # noqa: PLC0415
+
+        _log.debug("Loading CLIP model %s (%s)…", _MODEL_NAME, _PRETRAINED)
+        model, _, preprocess = open_clip.create_model_and_transforms(
+            _MODEL_NAME, pretrained=_PRETRAINED
+        )
+        model.eval()
+        _cached_model = model
+        _cached_preprocess = preprocess
+        self._model = model
+        self._preprocess = preprocess
+        _log.debug("CLIP model loaded.")
+
+    def _encode_batch(
+        self, paths: List[str]
+    ) -> Tuple["np.ndarray", int, List[str]]:
+        """Return (embeddings, error_count, successful_paths) for *paths*."""
+        import torch  # noqa: PLC0415
+        from PIL import Image  # noqa: PLC0415
+
+        tensors = []
+        successful: List[str] = []
+        errors = 0
+
+        for path in paths:
+            try:
+                img = Image.open(path).convert("RGB")
+                tensors.append(self._preprocess(img))  # type: ignore[misc]
+                successful.append(path)
+            except Exception as exc:  # noqa: BLE001
+                _log.warning("AI-Scan: could not open %s: %s", path, exc)
+                errors += 1
+
+        if not tensors:
+            return np.empty((0, 512), dtype=np.float32), errors, []
+
+        batch = torch.stack(tensors)
+        with torch.no_grad():
+            vecs = self._model.encode_image(batch).float()  # type: ignore[union-attr]
+
+        vecs_np = vecs.numpy()
+        norms = np.linalg.norm(vecs_np, axis=1, keepdims=True)
+        vecs_np = vecs_np / np.where(norms > 0, norms, 1.0)
+        return vecs_np.astype(np.float32), errors, successful
+
+
+def image_paths_for_folder(
+    folder_stamps: dict[str, tuple[float, int]],
+) -> List[str]:
+    """Convert a {path: (mtime, size)} dict from the repo into a plain path list."""
+    return list(folder_stamps.keys())

--- a/src/exif_turbo/ui/models/search_list_model.py
+++ b/src/exif_turbo/ui/models/search_list_model.py
@@ -175,6 +175,15 @@ class SearchListModel(QAbstractListModel):
         self._display_cache.extend([None] * len(rows))
         self.endInsertRows()
 
+    def prepend_rows(self, rows: List[SearchResult]) -> None:
+        if not rows:
+            return
+        self.beginInsertRows(QModelIndex(), 0, len(rows) - 1)
+        self._rows = list(rows) + self._rows
+        self._thumbnail_uris = ([None] * len(rows)) + self._thumbnail_uris
+        self._display_cache = ([None] * len(rows)) + self._display_cache
+        self.endInsertRows()
+
     def rowCount(self, parent: QModelIndex = QModelIndex()) -> int:
         if parent.isValid():
             return 0

--- a/src/exif_turbo/ui/models/settings_model.py
+++ b/src/exif_turbo/ui/models/settings_model.py
@@ -55,6 +55,7 @@ class SettingsModel(QObject):
     retranslateRequested = Signal()
     previewMaxSizeChanged = Signal()
     sortByChanged = Signal()
+    aiEnabledChanged = Signal()
 
     def __init__(self, settings_path: Path, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -65,6 +66,7 @@ class SettingsModel(QObject):
         self._language: str = "en"
         self._preview_max_size: int = _DEFAULT_PREVIEW_SIZE
         self._sort_by: str = _DEFAULT_SORT
+        self._ai_enabled: bool = True
         self._load()
 
     # ── Properties ───────────────────────────────────────────────────────────
@@ -92,6 +94,25 @@ class SettingsModel(QObject):
     @Property(bool, constant=True)
     def workersLocked(self) -> bool:
         return False
+
+    # ── AI features ───────────────────────────────────────────────────────────
+
+    @Property(bool, notify=aiEnabledChanged)
+    def aiEnabled(self) -> bool:
+        return self._ai_enabled
+
+    @property
+    def ai_enabled(self) -> bool:
+        """Python-only accessor for AppController."""
+        return self._ai_enabled
+
+    @Slot(bool)
+    def setAiEnabled(self, value: bool) -> None:
+        if self._ai_enabled == value:
+            return
+        self._ai_enabled = value
+        self.aiEnabledChanged.emit()
+        self._save()
 
     @Property("QVariantList", notify=blacklistChanged)
     def blacklist(self) -> List[str]:
@@ -229,6 +250,8 @@ class SettingsModel(QObject):
             if isinstance(data.get("language"), str) and data["language"] in {c for c, _ in available_languages()}:
                 self._language = data["language"]
                 apply_language(self._language)
+            if isinstance(data.get("aiEnabled"), bool):
+                self._ai_enabled = data["aiEnabled"]
         except Exception:
             pass  # corrupt/missing file — use defaults
 
@@ -243,6 +266,7 @@ class SettingsModel(QObject):
                         "previewMaxSize": self._preview_max_size,
                         "sortBy": self._sort_by,
                         "language": self._language,
+                        "aiEnabled": self._ai_enabled,
                     },
                     indent=2,
                 ),

--- a/src/exif_turbo/ui/models/settings_model.py
+++ b/src/exif_turbo/ui/models/settings_model.py
@@ -66,7 +66,7 @@ class SettingsModel(QObject):
         self._language: str = "en"
         self._preview_max_size: int = _DEFAULT_PREVIEW_SIZE
         self._sort_by: str = _DEFAULT_SORT
-        self._ai_enabled: bool = True
+        self._ai_enabled: bool = False
         self._load()
 
     # ── Properties ───────────────────────────────────────────────────────────

--- a/src/exif_turbo/ui/qml/FoldersPanel.qml
+++ b/src/exif_turbo/ui/qml/FoldersPanel.qml
@@ -332,6 +332,29 @@ Item {
                         }
                     }
 
+                    // AI-Scan button — CLIP vector embedding for this folder
+                    Button {
+                        flat: true
+                        visible: controller && controller.aiEnabled
+                        text: (controller && controller.isAiScanning && controller.aiScanFolderId === model.folderId)
+                              ? qsTr("Cancel AI-Scan")
+                              : qsTr("AI-Scan")
+                        font.pixelSize: 11
+                        implicitHeight: 30
+                        enabled: model.enabled && model.imageCount > 0 &&
+                                 (!controller || !controller.isAiScanning || controller.aiScanFolderId === model.folderId)
+                        ToolTip.text: (controller && controller.isAiScanning && controller.aiScanFolderId === model.folderId)
+                                      ? qsTr("Cancel the running AI-Scan")
+                                      : qsTr("Build CLIP vector embeddings for this folder (enables AI search)")
+                        ToolTip.visible: hovered
+                        onClicked: {
+                            if (controller.isAiScanning && controller.aiScanFolderId === model.folderId)
+                                controller.cancelAiScan()
+                            else
+                                controller.aiScanFolder(model.folderId)
+                        }
+                    }
+
                     // Clear Previews button — kept in layout (transparent when nothing cached)
                     // so the Remove button stays aligned across rows.
                     Button {
@@ -515,6 +538,17 @@ Item {
                     cancelText: qsTr("Cancel")
                     canceling: false  // preview cancel always allowed
                     onCancelRequested: controller.cancelPreviewBuild()
+                }
+
+                ProgressColumn {
+                    title: qsTr("AI-Scan")
+                    active: controller ? controller.isAiScanning : false
+                    current: controller ? controller.aiScanCurrent : 0
+                    total: controller ? controller.aiScanTotal : 0
+                    currentFile: controller ? controller.aiScanCurrentFile : ""
+                    cancelText: qsTr("Cancel")
+                    canceling: false
+                    onCancelRequested: controller.cancelAiScan()
                 }
             }
         }

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -123,6 +123,7 @@ ApplicationWindow {
             var next = Math.min(controller.currentResultRow + step, browseImageList.count - 1)
             controller.selectResult(next)
             browseImageList.positionViewAtIndex(next, ListView.Contain)
+            root._scheduleBrowseDirectionalPrefetch(1)
         }
     }
     Shortcut {
@@ -133,6 +134,7 @@ ApplicationWindow {
             var prev = Math.max(controller.currentResultRow - step, 0)
             controller.selectResult(prev)
             browseImageList.positionViewAtIndex(prev, ListView.Contain)
+            root._scheduleBrowseDirectionalPrefetch(-1)
         }
     }
     Shortcut {
@@ -143,6 +145,7 @@ ApplicationWindow {
             root._previewNavigating = true
             controller.selectResult(next)
             browseImageList.positionViewAtIndex(next, ListView.Contain)
+            root._scheduleBrowseDirectionalPrefetch(1)
         }
     }
     Shortcut {
@@ -153,6 +156,7 @@ ApplicationWindow {
             root._previewNavigating = true
             controller.selectResult(prev)
             browseImageList.positionViewAtIndex(prev, ListView.Contain)
+            root._scheduleBrowseDirectionalPrefetch(-1)
         }
     }
 
@@ -166,6 +170,10 @@ ApplicationWindow {
     property bool findBarVisible: false
     property bool browseFindBarVisible: false
     property bool _previewNavigating: false
+    property bool _aiSearchMode: false
+    property string _aiSearchPrecision: "normal"
+    readonly property bool _aiEnabled: controller ? controller.aiEnabled : true
+
 
     // ── Null-safe proxies ─────────────────────────────────────────────────
     readonly property bool   _isLocked:            controller ? controller.isLocked           : true
@@ -181,42 +189,16 @@ ApplicationWindow {
         function onClipboardCopyDone(message) {
             clipboardToast.show(message)
         }
+        function onFolderTreeChanged() {
+            root._scrollBrowseTreeToFolder()
+        }
         // Called after every search finishes (Browse folder load or Search tab restore).
         // Called after every search finishes (Browse folder load or Search tab restore).
         function onLoadedResultsChanged() {
             // Browse tab: jump to the pending target image once folder results are loaded.
             if (mainTabBar.currentIndex === 1 && root._pendingBrowseTargetId !== -1) {
-                var target = root._pendingBrowseTargetId
-                root._pendingBrowseTargetId = -1
-                var proxyRow = controller.selectResultById(target)
-                if (proxyRow >= 0) {
-                    // Use positionViewAtIndex (delegate-height-agnostic) and a
-                    // double Qt.callLater to run after the ListView's own layout
-                    // pass triggered by the currentProxyResultRow change inside
-                    // selectResultByPath.
-                    Qt.callLater(function() {
-                        Qt.callLater(function() {
-                            browseImageList.positionViewAtIndex(proxyRow, ListView.Beginning)
-                        })
-                    })
-                }
-                // Scroll the folder tree so the parent folder of the jumped-to image
-                // is visible. _folderFilter is already set by browseFolder() before
-                // results finish loading, so _folderTree can be searched here.
-                var folderPath = root._folderFilter
-                var treeIdx = -1
-                for (var i = 0; i < root._folderTree.length; i++) {
-                    if (root._folderTree[i].path === folderPath) {
-                        treeIdx = i
-                        break
-                    }
-                }
-                if (treeIdx >= 0) {
-                    var capturedTreeIdx = treeIdx
-                    Qt.callLater(function() {
-                        browseTreeList.positionViewAtIndex(capturedTreeIdx, ListView.Contain)
-                    })
-                }
+                root._applyPendingBrowseJump()
+                root._scrollBrowseTreeToFolder()
                 return
             }
             // Search tab: restore scroll position after returning from Browse tab.
@@ -374,6 +356,22 @@ ApplicationWindow {
     property real   _savedSearchScrollY:    -1.0
     // DB image id to locate and scroll to once Browse results finish loading; -1 = none
     property int    _pendingBrowseTargetId: -1
+    // Proxy row to scroll to once the Browse ListView has caught up to a
+    // pending target selection.
+    property int    _pendingBrowseScrollRow: -1
+    // Pending top-prepend restore state so inserting earlier rows keeps the
+    // current viewport stable instead of snapping back to the top.
+    property int    _pendingBrowsePrependCount: -1
+    property real   _pendingBrowsePrependContentY: -1.0
+    readonly property bool _browseJumpLoading: mainTabBar.currentIndex === 1
+                                              && (root._pendingBrowseTargetId !== -1
+                                                  || root._pendingBrowseScrollRow !== -1)
+    // Browse infinite-scroll prefetch state.
+    readonly property int _browsePageSize: 50
+    readonly property int _browseRowHeight: 210
+    readonly property int _browsePrefetchDistance: _browseRowHeight * _browsePageSize
+    property real   _lastBrowseContentY: 0.0
+    property bool   _suspendBrowsePrefetch: false
     // One-shot flag: restore resultsList position after the next search load
     property bool   _restoreSearchPosition: false
 
@@ -395,6 +393,132 @@ ApplicationWindow {
     // Parsed list of indexed folders for the folder combo
     readonly property var _searchFolderList: {
         try { return JSON.parse(_searchFolderListJson) } catch(e) { return [] }
+    }
+
+    function _scrollBrowseTreeToFolder() {
+        if (mainTabBar.currentIndex !== 1 || root._folderFilter === "" || root._folderTree.length === 0)
+            return
+        for (var i = 0; i < root._folderTree.length; i++) {
+            if (root._folderTree[i].path === root._folderFilter) {
+                var capturedTreeIdx = i
+                Qt.callLater(function() {
+                    browseTreeList.positionViewAtIndex(capturedTreeIdx, ListView.Contain)
+                })
+                return
+            }
+        }
+    }
+
+    function _browseVisibleRowCount() {
+        return Math.max(1, Math.ceil(browseImageList.height / root._browseRowHeight))
+    }
+
+    function _scheduleBrowseDirectionalPrefetch(direction) {
+        Qt.callLater(function() {
+            if (mainTabBar.currentIndex !== 1 || root._folderFilter === "")
+                return
+            if (direction > 0)
+                root._maybeLoadNextBrowsePage()
+            else if (direction < 0)
+                root._maybeLoadPreviousBrowsePage()
+        })
+    }
+
+    function _applyPendingBrowseJump() {
+        if (mainTabBar.currentIndex !== 1 || root._pendingBrowseTargetId === -1)
+            return
+        var proxyRow = controller.selectResultById(root._pendingBrowseTargetId)
+        if (proxyRow < 0) {
+            if (browseImageList.count < root._totalResults) {
+                Qt.callLater(function() {
+                    if (mainTabBar.currentIndex === 1 && root._pendingBrowseTargetId !== -1)
+                        controller.loadMore()
+                })
+            }
+            return
+        }
+        root._pendingBrowseTargetId = -1
+        root._pendingBrowseScrollRow = proxyRow
+        root._flushPendingBrowseScroll()
+    }
+
+    function _flushPendingBrowseScroll() {
+        if (mainTabBar.currentIndex !== 1)
+            return
+        var proxyRow = root._pendingBrowseScrollRow
+        if (proxyRow < 0)
+            return
+        if (browseImageList.count <= proxyRow)
+            return
+        if (browseImageList.currentIndex !== proxyRow)
+            return
+        Qt.callLater(function() {
+            Qt.callLater(function() {
+                if (mainTabBar.currentIndex !== 1 || root._pendingBrowseScrollRow !== proxyRow)
+                    return
+                root._suspendBrowsePrefetch = true
+                browseImageList.positionViewAtIndex(proxyRow, ListView.Beginning)
+                Qt.callLater(function() {
+                    root._suspendBrowsePrefetch = false
+                })
+                root._pendingBrowseScrollRow = -1
+            })
+        })
+    }
+
+    function _maybeLoadNextBrowsePage() {
+        if (mainTabBar.currentIndex !== 1 || root._folderFilter === "")
+            return
+        if (root._pendingBrowseTargetId !== -1 || root._pendingBrowseScrollRow !== -1)
+            return
+        if (browseImageList.count <= 0 || browseImageList.count >= root._totalResults)
+            return
+        var firstVisibleRow = Math.max(0, Math.floor(browseImageList.contentY / root._browseRowHeight))
+        var lastVisibleRow = firstVisibleRow + root._browseVisibleRowCount() - 1
+        var remainingRowsBelow = browseImageList.count - 1 - lastVisibleRow
+        if (remainingRowsBelow > root._browsePageSize)
+            return
+        controller.loadMore()
+    }
+
+    function _maybeLoadPreviousBrowsePage() {
+        if (mainTabBar.currentIndex !== 1 || root._folderFilter === "")
+            return
+        if (root._pendingBrowseTargetId !== -1 || root._pendingBrowseScrollRow !== -1)
+            return
+        if (root._pendingBrowsePrependCount >= 0)
+            return
+        if (browseImageList.count <= 0)
+            return
+        var firstVisibleRow = Math.max(0, Math.floor(browseImageList.contentY / root._browseRowHeight))
+        if (firstVisibleRow > root._browsePageSize)
+            return
+        root._pendingBrowsePrependCount = browseImageList.count
+        root._pendingBrowsePrependContentY = browseImageList.contentY
+        if (!controller.loadPrevious()) {
+            root._pendingBrowsePrependCount = -1
+            root._pendingBrowsePrependContentY = -1.0
+        }
+    }
+
+    function _restoreBrowsePrependPosition() {
+        if (root._pendingBrowsePrependCount < 0)
+            return
+        if (browseImageList.count <= root._pendingBrowsePrependCount)
+            return
+        var insertedRows = browseImageList.count - root._pendingBrowsePrependCount
+        var priorContentY = Math.max(0, root._pendingBrowsePrependContentY)
+        root._pendingBrowsePrependCount = -1
+        root._pendingBrowsePrependContentY = -1.0
+        Qt.callLater(function() {
+            if (mainTabBar.currentIndex !== 1)
+                return
+            root._suspendBrowsePrefetch = true
+            browseImageList.contentY = priorContentY + insertedRows * root._browseRowHeight
+            Qt.callLater(function() {
+                root._suspendBrowsePrefetch = false
+            })
+        })
     }
 
     // ── Dialogs ───────────────────────────────────────────────────────────
@@ -911,11 +1035,16 @@ ApplicationWindow {
     // ── Tab bar background (full-width row behind the buttons) ───────────
     // ── Search-in-progress overlay (dims UI and blocks input) ────────────
     Rectangle {
+        objectName: "searchBusyOverlay"
         anchors.fill: parent
         z: 55
-        visible: _isSearching
+        visible: _isSearching || root._browseJumpLoading
         color: Qt.rgba(0, 0, 0, 0.25)
-        MouseArea { anchors.fill: parent; hoverEnabled: true }
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.BusyCursor
+        }
     }
 
     // ── Tab bar background (full-width row behind the buttons) ───────────
@@ -979,6 +1108,7 @@ ApplicationWindow {
                 // Returning to Search: restore the snapshot, repopulate searchField,
                 // and request a one-shot scroll restore once results have loaded.
                 root._pendingBrowseTargetId = -1
+                root._pendingBrowseScrollRow = -1
                 root._restoreSearchPosition = true
                 var savedQuery = controller.leaveBrowseTab()
                 searchField.text = savedQuery
@@ -1029,6 +1159,115 @@ ApplicationWindow {
                             anchors { fill: parent; leftMargin: 10; rightMargin: 10; topMargin: 8; bottomMargin: 8 }
                             spacing: 6
 
+                            // ── EXIF / AI mode toggle pill ────────────────
+                            Rectangle {
+                                visible: root._aiEnabled
+                                implicitWidth: 82
+                                implicitHeight: 30
+                                radius: 4
+                                color: Qt.rgba(Material.foreground.r, Material.foreground.g, Material.foreground.b, 0.08)
+                                border.color: Qt.rgba(Material.foreground.r, Material.foreground.g, Material.foreground.b, 0.18)
+                                border.width: 1
+
+                                RowLayout {
+                                    anchors.fill: parent
+                                    spacing: 0
+
+                                    Button {
+                                        Layout.fillWidth: true
+                                        Layout.fillHeight: true
+                                        flat: true
+                                        text: qsTr("EXIF")
+                                        font.pixelSize: 11
+                                        font.bold: !root._aiSearchMode
+                                        highlighted: !root._aiSearchMode
+                                        onClicked: {
+                                            root._aiSearchMode = false
+                                            controller.setAiSearchMode(false)
+                                        }
+                                        topPadding: 0; bottomPadding: 0
+                                        leftPadding: 4; rightPadding: 4
+                                    }
+
+                                    Rectangle {
+                                        width: 1
+                                        Layout.fillHeight: true
+                                        color: Qt.rgba(Material.foreground.r, Material.foreground.g, Material.foreground.b, 0.18)
+                                    }
+
+                                    Button {
+                                        Layout.fillWidth: true
+                                        Layout.fillHeight: true
+                                        flat: true
+                                        text: qsTr("AI")
+                                        font.pixelSize: 11
+                                        font.bold: root._aiSearchMode
+                                        highlighted: root._aiSearchMode
+                                        onClicked: {
+                                            root._aiSearchMode = true
+                                            controller.setAiSearchMode(true)
+                                        }
+                                        topPadding: 0; bottomPadding: 0
+                                        leftPadding: 4; rightPadding: 4
+                                    }
+                                }
+                            }
+
+                            // ── AI precision picker (Fine / Normal / Broad) ─────────
+                            Rectangle {
+                                visible: root._aiSearchMode
+                                implicitWidth: 148
+                                implicitHeight: 30
+                                radius: 4
+                                color: Qt.rgba(Material.foreground.r, Material.foreground.g, Material.foreground.b, 0.08)
+                                border.color: Qt.rgba(Material.foreground.r, Material.foreground.g, Material.foreground.b, 0.18)
+                                border.width: 1
+
+                                RowLayout {
+                                    anchors.fill: parent
+                                    spacing: 0
+
+                                    Repeater {
+                                        model: [
+                                            { key: "fine",   label: qsTr("Fine")   },
+                                            { key: "normal", label: qsTr("Normal") },
+                                            { key: "broad",  label: qsTr("Broad")  },
+                                        ]
+
+                                        delegate: RowLayout {
+                                            spacing: 0
+                                            Layout.fillWidth: true
+                                            Layout.fillHeight: true
+
+                                            Rectangle {
+                                                visible: index > 0
+                                                width: 1
+                                                Layout.fillHeight: true
+                                                color: Qt.rgba(Material.foreground.r, Material.foreground.g, Material.foreground.b, 0.18)
+                                            }
+
+                                            Button {
+                                                Layout.fillWidth: true
+                                                Layout.fillHeight: true
+                                                flat: true
+                                                text: modelData.label
+                                                font.pixelSize: 11
+                                                font.bold: root._aiSearchPrecision === modelData.key
+                                                highlighted: root._aiSearchPrecision === modelData.key
+                                                onClicked: root._aiSearchPrecision = modelData.key
+                                                topPadding: 0; bottomPadding: 0
+                                                leftPadding: 4; rightPadding: 4
+                                                ToolTip.text: modelData.key === "fine"   ? qsTr("Precise — score ≥ 0.22 (strictest)")  :
+                                                              modelData.key === "normal" ? qsTr("Balanced — score ≥ 0.20")               :
+                                                                                           qsTr("Broad — score ≥ 0.18 (most results)")
+                                                ToolTip.visible: hovered
+                                                ToolTip.delay: 600
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
                             Rectangle {
                                 Layout.fillWidth: true
                                 implicitHeight: 36
@@ -1040,7 +1279,7 @@ ApplicationWindow {
                                 Label {
                                     anchors { left: parent.left; leftMargin: 10; verticalCenter: parent.verticalCenter }
                                     visible: searchField.text.length === 0
-                                    text: qsTr("Search EXIF metadata\u2026")
+                                    text: root._aiSearchMode ? qsTr("Describe what you\u2019re looking for\u2026") : qsTr("Search EXIF metadata\u2026")
                                     font.pixelSize: 13
                                     opacity: 0.4
                                 }
@@ -1053,7 +1292,7 @@ ApplicationWindow {
                                     selectedTextColor: "white"
                                     selectionColor: root._accentColor
                                     clip: true
-                                    Keys.onReturnPressed: controller.search(text)
+                                    Keys.onReturnPressed: root._aiSearchMode ? controller.aiSearch(text, root._aiSearchPrecision) : controller.search(text)
                                 }
 
                                 // Clear button — visible whenever the field has text
@@ -1085,11 +1324,12 @@ ApplicationWindow {
                                     }
                                 }
 
-                                // Help (?) button — shows search-syntax hints on hover
+                                // Help (?) button — shows search-syntax hints on hover — EXIF mode only
                                 Item {
                                     id: searchHelpButton
                                     anchors { right: parent.right; rightMargin: 6; verticalCenter: parent.verticalCenter }
                                     width: 20; height: 20
+                                    visible: !root._aiSearchMode
 
                                     Text {
                                         anchors.centerIn: parent
@@ -1180,7 +1420,7 @@ ApplicationWindow {
                                 highlighted: true
                                 implicitHeight: 36
                                 font.pixelSize: 13
-                                onClicked: controller.search(searchField.text)
+                                onClicked: root._aiSearchMode ? controller.aiSearch(searchField.text, root._aiSearchPrecision) : controller.search(searchField.text)
                             }
                         }
                     }
@@ -1210,7 +1450,7 @@ ApplicationWindow {
                                 text: qsTr("Folder(s)")
                                 font.pixelSize: 11
                                 opacity: 0.6
-                                visible: root._indexedFolderCount > 1
+                                visible: root._indexedFolderCount > 1 && !root._aiSearchMode
                             }
 
                             // Checked-only filter chip
@@ -1257,7 +1497,7 @@ ApplicationWindow {
                             ComboBox {
                                 id: folderMultiCombo
                                 objectName: "folderMultiCombo"
-                                visible: root._indexedFolderCount > 1
+                                visible: root._indexedFolderCount > 1 && !root._aiSearchMode
                                 implicitHeight: 28
                                 implicitWidth: 170
                                 font.pixelSize: 11
@@ -1317,11 +1557,13 @@ ApplicationWindow {
                                 text: qsTr("Sort")
                                 font.pixelSize: 11
                                 opacity: 0.6
+                                visible: !root._aiSearchMode
                             }
 
                             ComboBox {
                                 id: sortCombo
                                 objectName: "sortCombo"
+                                visible: !root._aiSearchMode
                                 implicitHeight: 28
                                 font.pixelSize: 11
 
@@ -1448,7 +1690,7 @@ ApplicationWindow {
                         readonly property bool _hasYears: root._years.length > 0
                         readonly property bool _filterActive: root._dateFrom !== -1 || root._dateTo !== -1
                         implicitHeight: _hasYears ? contentRowLayout.implicitHeight + 8 : 0
-                        visible: _hasYears
+                        visible: _hasYears && !root._aiSearchMode
                         color: Qt.rgba(root._accentColor.r, root._accentColor.g, root._accentColor.b, 0.04)
 
                         // Tooltip for the whole filter strip (non-blocking).
@@ -2615,7 +2857,7 @@ ApplicationWindow {
         visible: !_isLocked && mainTabBar.currentIndex === 1
         orientation: Qt.Horizontal
 
-        onVisibleChanged: { if (visible) controller.reloadFolderTree() }
+        onVisibleChanged: { if (visible) controller.loadFolderTree() }
         handle: Rectangle {
             implicitWidth: 5
             color: SplitHandle.pressed ? root._accentColor : Material.dividerColor
@@ -2670,6 +2912,7 @@ ApplicationWindow {
 
                 ListView {
                     id: browseTreeList
+                    objectName: "browseTreeList"
                     Layout.fillWidth: true
                     Layout.fillHeight: true
                     clip: true
@@ -2737,8 +2980,11 @@ ApplicationWindow {
         // ── Image list + preview + metadata ──────────────────────────────
         SplitView {
             id: browseContentSplit
+            objectName: "browseContentSplit"
             SplitView.fillWidth: true
             orientation: Qt.Vertical
+            opacity: root._browseJumpLoading ? 0.0 : 1.0
+            enabled: !root._browseJumpLoading
             handle: Rectangle {
                 implicitHeight: 5
                 color: SplitHandle.pressed ? root._accentColor : Material.dividerColor
@@ -2811,7 +3057,7 @@ ApplicationWindow {
 
                             Label {
                                 text: root._folderFilter !== ""
-                                      ? browseImageList.count + qsTr(" images")
+                                      ? root._totalResults + qsTr(" images")
                                       : qsTr("Select a folder")
                                 font.pixelSize: 11; opacity: 0.6
                             }
@@ -2838,6 +3084,9 @@ ApplicationWindow {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         clip: true
+                        cacheBuffer: root._browsePrefetchDistance
+                        displayMarginBeginning: root._browsePrefetchDistance
+                        displayMarginEnd: root._browsePrefetchDistance
                         visible: root._folderFilter !== ""
                         focus: visible
                         activeFocusOnTab: true
@@ -2851,6 +3100,30 @@ ApplicationWindow {
                         }
 
                         onVisibleChanged: { if (visible) forceActiveFocus() }
+                        onContentYChanged: {
+                            var previousContentY = root._lastBrowseContentY
+                            root._lastBrowseContentY = contentY
+                            if (root._suspendBrowsePrefetch) {
+                                root._suspendBrowsePrefetch = false
+                                return
+                            }
+                            if (!visible || count <= 0 || root._folderFilter === "")
+                                return
+                            if (contentY > previousContentY)
+                                root._maybeLoadNextBrowsePage()
+                            else if (contentY < previousContentY)
+                                root._maybeLoadPreviousBrowsePage()
+                        }
+                        onCurrentIndexChanged: root._flushPendingBrowseScroll()
+                        onCountChanged: {
+                            root._flushPendingBrowseScroll()
+                            root._restoreBrowsePrependPosition()
+                        }
+                        onContentHeightChanged: root._flushPendingBrowseScroll()
+                        onHeightChanged: root._flushPendingBrowseScroll()
+                        onAtYBeginningChanged: {
+                            if (atYBeginning && count > 0) root._maybeLoadPreviousBrowsePage()
+                        }
 
                         delegate: Rectangle {
                             id: browseCardDelegate
@@ -4069,6 +4342,44 @@ ApplicationWindow {
 
                     // spacer below the section
                     Item { height: 28; Layout.fillWidth: true }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Material.dividerColor; Layout.bottomMargin: 28 }
+
+                    // ── AI Features ───────────────────────────────────────
+                    Label {
+                        text: qsTr("AI Features")
+                        font.pixelSize: 14
+                        font.weight: Font.DemiBold
+                        Layout.bottomMargin: 6
+                    }
+                    Label {
+                        text: qsTr("Enable CLIP-based semantic image search and AI-Scan for indexed folders. Requires the open-clip-torch package and downloads a ~350 MB model on first use.")
+                        font.pixelSize: 12
+                        opacity: 0.6
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                        Layout.bottomMargin: 12
+                    }
+                    RowLayout {
+                        spacing: 12
+                        Layout.bottomMargin: 28
+
+                        Switch {
+                            id: aiEnabledSwitch
+                            checked: controller ? controller.aiEnabled : true
+                            onToggled: {
+                                controller.setAiEnabled(checked)
+                                if (!checked) root._aiSearchMode = false
+                            }
+                        }
+
+                        Label {
+                            text: aiEnabledSwitch.checked ? qsTr("Enabled") : qsTr("Disabled")
+                            font.pixelSize: 13
+                            opacity: 0.8
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
 
                     Rectangle { Layout.fillWidth: true; height: 1; color: Material.dividerColor; Layout.bottomMargin: 28 }
 

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -238,7 +238,7 @@ class AppController(QObject):
         self._ai_scan_worker: AiScanWorker | None = None
         self._is_ai_scanning: bool = False
         self._is_ai_search_mode: bool = False
-        self._ai_enabled: bool = self._settings.ai_enabled if self._settings else True
+        self._ai_enabled: bool = self._settings.ai_enabled if self._settings else False
         self._ai_search_worker: AiSearchWorker | None = None
         self._last_ai_query: str = ""
         self._last_ai_precision: str = "normal"

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -39,16 +39,19 @@ from ..models.exif_list_model import ExifListModel
 from ..models.folder_list_model import FolderListModel
 from ..models.search_list_model import SearchListModel
 from ..models.settings_model import SettingsModel
+from ..workers.ai_scan_worker import AiScanWorker
+from ..workers.ai_search_worker import AiSearchWorker
 from ..workers.bulk_op_worker import BulkOpWorker
 from ..workers.folder_tree_worker import FolderTreeWorker
 from ..workers.index_worker import IndexWorker
 from ..workers.password_change_worker import PasswordChangeWorker
 from ..workers.preview_build_worker import PreviewBuildWorker
-from ..workers.search_worker import SearchWorker
+from ..workers.search_worker import SearchPageWorker, SearchWorker
 from ..workers.thumb_worker import ThumbWorker
 from ...utils.preview_render import MAX_PREVIEW_PX, render_preview
 
 _PAGE_SIZE = 50
+_BROWSE_JUMP_PAGE_SIZE = 500
 _DEFAULT_WORKERS = max(1, (os.cpu_count() or 2) // 2)
 # Pillow LANCZOS resampling is GIL-bound; running too many thumb threads while
 # IndexWorker is active starves the scan thread and GUI event loop on Windows.
@@ -80,6 +83,13 @@ class AppController(QObject):
     isIndexingChanged = Signal()
     isBuildingThumbsChanged = Signal()
     isBuildingPreviewsChanged = Signal()
+    isAiScanningChanged = Signal()
+    isAiSearchModeChanged = Signal()
+    aiEnabledChanged = Signal()
+    aiScanFolderIdChanged = Signal()
+    aiScanCurrentChanged = Signal()
+    aiScanTotalChanged = Signal()
+    aiScanCurrentFileChanged = Signal()
     previewBuildFolderIdChanged = Signal()
     previewCurrentChanged = Signal()
     previewTotalChanged = Signal()
@@ -180,6 +190,7 @@ class AppController(QObject):
         self._preview_bust: int = 0
         self._total_results = 0
         self._loaded_results = 0
+        self._loaded_offset = 0
         self._loading = False
         self._search_error: str = ""
         self._details_plain_text = ""
@@ -201,12 +212,13 @@ class AppController(QObject):
         # the previously-selected image (identified by its DB id) is included in
         # the model.  0 means no pending restore.
         self._pending_restore_image_id: int = 0
-        # When jumping from Search → Browse, preload pages until the target
-        # image id is in the model.  0 means no pending jump.
+        # When jumping from Search → Browse, keep the target image id here
+        # until it is actually loaded and selected in the Browse model.
         self._pending_browse_jump_id: int = 0
         self._folder_tree: str = "[]"
         self._folder_tree_dirty: bool = False
         self._folder_tree_worker: FolderTreeWorker | None = None
+        self._folder_tree_worker_shows_busy_ui: bool = False
         self._pending_preview_path: str = ""
         # DB-stored (mtime, size) for the pending preview; used to compute the
         # on-disk cache filename without statting the (possibly missing) source.
@@ -223,6 +235,22 @@ class AppController(QObject):
         self._preview_total: int = 0
         self._preview_current_file: str = ""
         self._preview_oversized_skipped: int = 0
+        self._ai_scan_worker: AiScanWorker | None = None
+        self._is_ai_scanning: bool = False
+        self._is_ai_search_mode: bool = False
+        self._ai_enabled: bool = self._settings.ai_enabled if self._settings else True
+        self._ai_search_worker: AiSearchWorker | None = None
+        self._last_ai_query: str = ""
+        self._last_ai_precision: str = "normal"
+        # Set to True by aiSearch() so _on_search_finished always selects row 0
+        # for a fresh AI search (not a browse-restore).
+        self._ai_select_first: bool = False
+        # All AI result rows held in memory so we can page them without SQL.
+        self._ai_result_cache: list[SearchResult] = []
+        self._ai_scan_folder_id: int = 0
+        self._ai_scan_current: int = 0
+        self._ai_scan_total: int = 0
+        self._ai_scan_current_file: str = ""
         self._use_raw_preview: bool = False
         self._scanning_folder_id: int | None = None
         self._scan_queue: list[tuple[int, bool]] = []
@@ -231,6 +259,8 @@ class AppController(QObject):
         self._app_closing = False
         self._pending_thumb_restart = False
         self._search_worker: SearchWorker | None = None
+        self._load_more_worker: SearchPageWorker | None = None
+        self._page_load_mode = "append"
         self._search_serial: int = 0
         self._date_from: int | None = None
         self._date_to: int | None = None
@@ -241,10 +271,12 @@ class AppController(QObject):
         # its C++ stack (which holds a reference via AutoDecRef).  Each worker
         # is removed in _on_search_worker_done, which is connected to
         # QThread.finished — emitted only after run() has fully returned.
-        self._finishing_search_workers: set[SearchWorker] = set()
+        self._finishing_search_workers: set[QThread] = set()
         # Params for a search that arrived while one was already in-flight.
         # Consumed immediately when the current worker finishes.
         self._pending_search_params: dict | None = None
+        self._pending_search_show_busy_ui: bool = True
+        self._search_shows_busy_ui: bool = False
         self._filter_proxy: CheckedFilterProxyModel | None = None
         self._checked_only_filter_active: bool = False
         self._checked_in_results_count: int = 0
@@ -347,6 +379,51 @@ class AppController(QObject):
     @Property(bool, notify=useRawPreviewChanged)
     def useRawPreview(self) -> bool:
         return self._use_raw_preview
+
+    # ── AI-scan state ──────────────────────────────────────────────────────────
+
+    @Property(bool, notify=isAiScanningChanged)
+    def isAiScanning(self) -> bool:
+        return self._is_ai_scanning
+
+    @Property(int, notify=aiScanFolderIdChanged)
+    def aiScanFolderId(self) -> int:
+        return self._ai_scan_folder_id
+
+    @Property(int, notify=aiScanCurrentChanged)
+    def aiScanCurrent(self) -> int:
+        return self._ai_scan_current
+
+    @Property(int, notify=aiScanTotalChanged)
+    def aiScanTotal(self) -> int:
+        return self._ai_scan_total
+
+    @Property(str, notify=aiScanCurrentFileChanged)
+    def aiScanCurrentFile(self) -> str:
+        return self._ai_scan_current_file
+
+    # ── AI-search mode ─────────────────────────────────────────────────────────
+
+    @Property(bool, notify=isAiSearchModeChanged)
+    def isAiSearchMode(self) -> bool:
+        return self._is_ai_search_mode
+
+    @Property(bool, notify=aiEnabledChanged)
+    def aiEnabled(self) -> bool:
+        return self._ai_enabled
+
+    @Slot(bool)
+    def setAiEnabled(self, value: bool) -> None:
+        if self._ai_enabled == value:
+            return
+        self._ai_enabled = value
+        if self._settings:
+            self._settings.setAiEnabled(value)
+        # If AI is turned off while in AI mode, revert to EXIF mode.
+        if not value and self._is_ai_search_mode:
+            self._is_ai_search_mode = False
+            self.isAiSearchModeChanged.emit()
+        self.aiEnabledChanged.emit()
 
     @Property(bool, notify=isCancelingChanged)
     def isCanceling(self) -> bool:
@@ -1192,12 +1269,29 @@ class AppController(QObject):
         if self._folder_filter == path:
             self._folder_filter = ""
             self._pending_browse_jump_id = 0
+            search_offset = 0
         else:
             self._query_text = ""
             self._folder_filter = path
             self._pending_browse_jump_id = target_id
+            search_offset = 0
+            if target_id and self._repo is not None:
+                target_offset = self._repo.find_image_offset(
+                    target_id,
+                    query=self._query_text,
+                    sort_by=self._sort_by,
+                    ext_filter=self._ext_filter,
+                    path_filter=[path],
+                    restrict_to_enabled_folders=(self._folder_repo is not None),
+                    marked_only=self._checked_only_filter_active,
+                    date_from=self._date_from,
+                    date_to=self._date_to,
+                )
+                if target_offset is not None:
+                    search_offset = max(0, target_offset - (_PAGE_SIZE // 2))
+        show_busy_ui = self._pending_browse_jump_id != 0
         self.folderFilterChanged.emit()
-        self._run_search()
+        self._run_search(show_busy_ui=show_busy_ui, offset=search_offset)
 
     @Slot(str)
     def enterBrowseTab(self, query_text: str = "") -> None:
@@ -1221,8 +1315,15 @@ class AppController(QObject):
             "date_from": self._date_from,
             "date_to": self._date_to,
             "checked_only_filter": self._checked_only_filter_active,
+            "was_ai_search_mode": self._is_ai_search_mode,
             "current_image_id": self._search_model.get_image_id(self._current_result_row) or 0,
+            "ai_rows": list(self._ai_result_cache) if self._is_ai_search_mode else None,
+            "ai_total_results": self._total_results if self._is_ai_search_mode else 0,
+            "ai_loaded_results": self._loaded_results if self._is_ai_search_mode else 0,
         }
+        if self._is_ai_search_mode:
+            self._is_ai_search_mode = False
+            self.isAiSearchModeChanged.emit()
         self._query_text = ""
         if self._search_folder_filters:
             self._search_folder_filters.clear()
@@ -1262,10 +1363,12 @@ class AppController(QObject):
             self._query_text = ""
             self._run_search()
             return ""
+        restore_ai_search_mode = bool(snapshot.get("was_ai_search_mode", False))
+        if self._is_ai_search_mode != restore_ai_search_mode:
+            self._is_ai_search_mode = restore_ai_search_mode
+            self.isAiSearchModeChanged.emit()
         self._query_text = snapshot["query_text"]
         image_id = snapshot.get("current_image_id", 0)
-        if image_id:
-            self._pending_restore_image_id = image_id
         restored_search_folders = snapshot["search_folder_filters"]
         if restored_search_folders != self._search_folder_filters:
             self._search_folder_filters = restored_search_folders
@@ -1283,7 +1386,34 @@ class AppController(QObject):
         if snapshot.get("checked_only_filter", False) != self._checked_only_filter_active:
             self._checked_only_filter_active = snapshot.get("checked_only_filter", False)
             self.checkedOnlyFilterChanged.emit()
-        self._run_search()
+        if self._is_ai_search_mode and snapshot.get("ai_rows") is not None:
+            # Restore AI results directly — no re-search, no model reload.
+            saved_rows = snapshot["ai_rows"]
+            self._ai_result_cache = saved_rows
+            self._loaded_offset = 0
+            self._loading = True
+            self._search_model.set_rows(saved_rows[:_PAGE_SIZE])
+            self._recompute_checked_in_results()
+            self.checkedCountChanged.emit()
+            self._total_results = snapshot["ai_total_results"]
+            self._loaded_results = min(len(saved_rows), _PAGE_SIZE)
+            if image_id and self._loaded_results > 0:
+                if self.selectResultById(image_id) < 0:
+                    self._select_source_row(0)
+            elif self._loaded_results > 0:
+                self._select_source_row(
+                    self._current_result_row
+                    if 0 <= self._current_result_row < self._loaded_results
+                    else 0
+                )
+            self.totalResultsChanged.emit()
+            self.loadedResultsChanged.emit()
+            self._loading = False
+            self._load_year_counts()
+        else:
+            if image_id:
+                self._pending_restore_image_id = image_id
+            self._run_search()
         return self._query_text
 
     @Slot(float, float)
@@ -1309,14 +1439,24 @@ class AppController(QObject):
         self.dateFilterChanged.emit()
         self._run_search()
 
-    def _run_search(self) -> None:
+    def _set_search_busy_ui(self, active: bool) -> None:
+        if self._is_searching == active:
+            return
+        self._is_searching = active
+        if active:
+            QGuiApplication.setOverrideCursor(QCursor(Qt.CursorShape.BusyCursor))
+        else:
+            QGuiApplication.restoreOverrideCursor()
+        self.isSearchingChanged.emit()
+
+    def _run_search(self, show_busy_ui: bool = True, offset: int = 0) -> None:
         if self._repo is None or self._db_path is None:
             return
         path_filter = self._current_path_filter()
         params = dict(
             query=self._query_text,
             page_size=_PAGE_SIZE,
-            offset=0,
+            offset=offset,
             sort_by=self._sort_by,
             ext_filter=self._ext_filter,
             path_filter=path_filter,
@@ -1331,6 +1471,7 @@ class AppController(QObject):
             # the current one closes its connection.  This keeps at most
             # one SearchWorker (and one extra DB connection) alive at a time.
             self._pending_search_params = params
+            self._pending_search_show_busy_ui = show_busy_ui
             self._search_serial += 1  # serial bump marks in-flight result stale
             return
 
@@ -1347,9 +1488,8 @@ class AppController(QObject):
         worker.failed.connect(self._on_search_failed)
         worker.finished.connect(self._on_search_worker_done)
         self._search_worker = worker
-        QGuiApplication.setOverrideCursor(QCursor(Qt.CursorShape.BusyCursor))
-        self._is_searching = True
-        self.isSearchingChanged.emit()
+        self._search_shows_busy_ui = show_busy_ui
+        self._set_search_busy_ui(show_busy_ui)
         worker.start()
 
     def _on_search_worker_done(self) -> None:
@@ -1369,6 +1509,8 @@ class AppController(QObject):
         format_counts: list,
         serial: int,
     ) -> None:
+        if self.sender() is self._ai_search_worker:
+            self._ai_search_worker = None
         old_worker = self._search_worker
         self._search_worker = None
         # Keep a Python reference to the outgoing worker until QThread.finished
@@ -1382,6 +1524,7 @@ class AppController(QObject):
         if self._pending_search_params is not None:
             pending = self._pending_search_params
             self._pending_search_params = None
+            pending_show_busy_ui = self._pending_search_show_busy_ui
             serial_now = self._search_serial
             worker = SearchWorker(
                 self._db_path,
@@ -1393,26 +1536,42 @@ class AppController(QObject):
             worker.failed.connect(self._on_search_failed)
             worker.finished.connect(self._on_search_worker_done)
             self._search_worker = worker
+            self._search_shows_busy_ui = pending_show_busy_ui
+            self._set_search_busy_ui(pending_show_busy_ui)
             worker.start()
             return
         # Discard results that belong to a superseded search.
         if serial != self._search_serial:
-            QGuiApplication.restoreOverrideCursor()
-            self._is_searching = False
-            self.isSearchingChanged.emit()
+            self._search_shows_busy_ui = False
+            self._set_search_busy_ui(False)
             return
         self._set_search_error("")
-        results = [
+        search_offset = 0
+        sender = self.sender()
+        if isinstance(sender, SearchWorker):
+            search_offset = sender._offset  # type: ignore[attr-defined]
+        all_results = [
             SearchResult(image_id=r[0], path=r[1], filename=r[2], metadata_json=r[3], size=r[4], mtime=r[5])
             for r in rows
         ]
+        # For AI searches, store all results in-memory and load only the first
+        # page into the model; further pages are served from _ai_result_cache
+        # by loadMore() without touching the database.
+        if self._is_ai_search_mode:
+            self._ai_result_cache = all_results
+            first_page = all_results[:_PAGE_SIZE]
+            self._loaded_offset = 0
+        else:
+            self._ai_result_cache = []
+            first_page = all_results
+            self._loaded_offset = search_offset
         # Block loadMore for the duration of the model reset.  Without this
         # guard, endResetModel() causes the Browse ListView to fire loadMore
         # (stale _loaded_results < _total_results), which emits
         # loadedResultsChanged prematurely and consumes _pendingBrowseTarget
         # before the real emission at the end of this method.
         self._loading = True
-        self._search_model.set_rows(results)
+        self._search_model.set_rows(first_page)
         # When the "checked only" filter is active, every row is marked,
         # so total == checked-in-results. Otherwise recompute against the
         # full filtered set (not just the loaded page).
@@ -1422,7 +1581,7 @@ class AppController(QObject):
             self._recompute_checked_in_results()
         self.checkedCountChanged.emit()
         self._total_results = total
-        self._loaded_results = len(results)
+        self._loaded_results = len(first_page)
         # Returning from Browse: synchronously load enough additional pages
         # so the previously-selected image is reachable in the model before
         # the QML scroll-restore handler runs.  Uses the DB image id so a
@@ -1432,38 +1591,6 @@ class AppController(QObject):
             target_id = self._pending_restore_image_id
             while (
                 self._search_model.find_row_by_id(target_id) < 0
-                and self._loaded_results < self._total_results
-            ):
-                more_rows = self._repo.search_images(
-                    self._query_text,
-                    _PAGE_SIZE,
-                    self._loaded_results,
-                    sort_by=self._sort_by,
-                    ext_filter=self._ext_filter,
-                    path_filter=self._current_path_filter(),
-                    restrict_to_enabled_folders=(self._folder_repo is not None),
-                    marked_only=self._checked_only_filter_active,
-                    date_from=self._date_from,
-                    date_to=self._date_to,
-                )
-                if not more_rows:
-                    break
-                more_results = [
-                    SearchResult(
-                        image_id=r[0], path=r[1], filename=r[2], metadata_json=r[3],
-                        size=r[4], mtime=r[5],
-                    )
-                    for r in more_rows
-                ]
-                self._search_model.append_rows(more_results)
-                self._loaded_results += len(more_results)
-        # Forward Browse jump (Search → Browse): preload pages until the target
-        # image is in the model so QML's selectResultById call succeeds.
-        if self._pending_browse_jump_id and self._repo is not None:
-            jump_id = self._pending_browse_jump_id
-            self._pending_browse_jump_id = 0
-            while (
-                self._search_model.find_row_by_id(jump_id) < 0
                 and self._loaded_results < self._total_results
             ):
                 more_rows = self._repo.search_images(
@@ -1502,16 +1629,29 @@ class AppController(QObject):
                 # Image was deleted from the index while browsing; fall back.
                 self._select_source_row(0)
             _did_restore = True
+        # Fresh AI search: always land on row 0 (FAISS best match).
+        if self._ai_select_first:
+            self._ai_select_first = False
+            if self._loaded_results > 0 and not _did_restore:
+                self._select_source_row(0)
+                _did_restore = True
         # Keep _loading=True through both emits so loadMore cannot fire
         # prematurely during totalResultsChanged or loadedResultsChanged and
         # consume _pendingBrowseTarget before onLoadedResultsChanged handles it.
+        pending_browse_jump_id = self._pending_browse_jump_id
+        had_pending_browse_jump = pending_browse_jump_id != 0
+        if (
+            had_pending_browse_jump
+            and self._search_model.find_row_by_id(pending_browse_jump_id) < 0
+        ):
+            self._clear_details()
         self.totalResultsChanged.emit()
         self.loadedResultsChanged.emit()
         self._loading = False
         self._apply_format_counts(format_counts)
         self._load_year_counts()
         if self._loaded_results > 0:
-            if not _did_restore:
+            if not _did_restore and not had_pending_browse_jump:
                 row = (
                     self._current_result_row
                     if 0 <= self._current_result_row < self._loaded_results
@@ -1520,11 +1660,12 @@ class AppController(QObject):
                 self._select_source_row(row)
         else:
             self._clear_details()
-        QGuiApplication.restoreOverrideCursor()
-        self._is_searching = False
-        self.isSearchingChanged.emit()
+        self._search_shows_busy_ui = False
+        self._set_search_busy_ui(False)
 
     def _on_search_failed(self, error: str) -> None:
+        if self.sender() is self._ai_search_worker:
+            self._ai_search_worker = None
         old_worker = self._search_worker
         self._search_worker = None
         if old_worker is not None:
@@ -1534,15 +1675,15 @@ class AppController(QObject):
         self._search_model.set_rows([])
         self._total_results = 0
         self._loaded_results = 0
+        self._loaded_offset = 0
         self._loading = False
         self._checked_in_results_count = 0
         self.checkedCountChanged.emit()
         self.totalResultsChanged.emit()
         self.loadedResultsChanged.emit()
         self._clear_details()
-        QGuiApplication.restoreOverrideCursor()
-        self._is_searching = False
-        self.isSearchingChanged.emit()
+        self._search_shows_busy_ui = False
+        self._set_search_busy_ui(False)
 
     def _apply_format_counts(self, counts: list) -> None:
         """Update the available-formats property from a pre-fetched counts list."""
@@ -1584,15 +1725,24 @@ class AppController(QObject):
         """Mark the folder tree as stale; it will be rebuilt on next Browse tab visit."""
         self._folder_tree_dirty = True
 
+    def _start_folder_tree_worker(self, show_busy_ui: bool) -> None:
+        if self._repo is None or self._folder_tree_worker is not None:
+            return
+        self._folder_tree_worker_shows_busy_ui = show_busy_ui
+        if show_busy_ui:
+            self._is_searching = True
+            self.isSearchingChanged.emit()
+        self._folder_tree_worker = FolderTreeWorker(self._db_path, self._key)
+        self._folder_tree_worker.results_ready.connect(self._on_folder_tree_ready)
+        self._folder_tree_worker.failed.connect(self._on_folder_tree_failed)
+        self._folder_tree_worker.start()
+
     @Slot()
     def loadFolderTree(self) -> None:
-        """Load (or reload) the folder tree — called by QML when Browse tab is activated."""
+        """Load the folder tree in the background when Browse becomes visible."""
         if self._repo is None or not self._folder_tree_dirty:
             return
-        nodes = self._repo.get_folder_tree()
-        self._folder_tree = json.dumps(nodes)
-        self._folder_tree_dirty = False
-        self.folderTreeChanged.emit()
+        self._start_folder_tree_worker(show_busy_ui=False)
 
     def _load_folder_tree(self) -> None:
         if self._repo is None:
@@ -1609,51 +1759,143 @@ class AppController(QObject):
         the grey-out is actually visible (the worker thread keeps the
         event loop free for rendering).
         """
-        if self._repo is None or self._is_searching:
+        if self._repo is None or self._folder_tree_worker is not None:
             return
-        self._is_searching = True
-        self.isSearchingChanged.emit()
-        self._folder_tree_worker = FolderTreeWorker(self._db_path, self._key)
-        self._folder_tree_worker.results_ready.connect(self._on_folder_tree_ready)
-        self._folder_tree_worker.failed.connect(self._on_folder_tree_failed)
-        self._folder_tree_worker.start()
+        self._start_folder_tree_worker(show_busy_ui=True)
 
     def _on_folder_tree_ready(self, json_str: str) -> None:
         self._folder_tree_worker = None
         self._folder_tree = json_str
         self._folder_tree_dirty = False
-        self._is_searching = False
+        if self._folder_tree_worker_shows_busy_ui:
+            self._is_searching = False
+            self.isSearchingChanged.emit()
+            self._set_status(_("Folder list reloaded."))
+        self._folder_tree_worker_shows_busy_ui = False
         self.folderTreeChanged.emit()
-        self.isSearchingChanged.emit()
-        self._set_status(_("Folder list reloaded."))
 
     def _on_folder_tree_failed(self, error: str) -> None:
         self._folder_tree_worker = None
-        self._is_searching = False
-        self.isSearchingChanged.emit()
+        if self._folder_tree_worker_shows_busy_ui:
+            self._is_searching = False
+            self.isSearchingChanged.emit()
+        self._folder_tree_worker_shows_busy_ui = False
         _log.error("Folder tree reload failed: %s", error)
 
-    @Slot()
-    def loadMore(self) -> None:
-        if self._repo is None or self._loading or self._loaded_results >= self._total_results:
-            return
+    @Slot(result=bool)
+    def loadMore(self) -> bool:
+        if self._loading:
+            return False
+        if self._is_ai_search_mode:
+            if self._loaded_results >= self._total_results:
+                return False
+            next_page = self._ai_result_cache[
+                self._loaded_results : self._loaded_results + _PAGE_SIZE
+            ]
+            if not next_page:
+                return False
+            self._loading = True
+            self._search_model.append_rows(next_page)
+            self._loaded_results += len(next_page)
+            self.loadedResultsChanged.emit()
+            self._loading = False
+            return True
+        if self._loaded_offset + self._loaded_results >= self._total_results:
+            return False
+        if self._db_path is None:
+            return False
+        page_size = _PAGE_SIZE
+        if self._pending_browse_jump_id:
+            page_size = _BROWSE_JUMP_PAGE_SIZE
         self._loading = True
-        rows = self._repo.search_images(
-            self._query_text, _PAGE_SIZE, self._loaded_results,
-            sort_by=self._sort_by, ext_filter=self._ext_filter,
+        self._page_load_direction = "append"
+        worker = SearchPageWorker(
+            self._db_path,
+            self._key,
+            query=self._query_text,
+            page_size=page_size,
+            offset=self._loaded_offset + self._loaded_results,
+            sort_by=self._sort_by,
+            ext_filter=self._ext_filter,
             path_filter=self._current_path_filter(),
             restrict_to_enabled_folders=(self._folder_repo is not None),
             marked_only=self._checked_only_filter_active,
+            serial=self._search_serial,
             date_from=self._date_from,
             date_to=self._date_to,
         )
+        worker.results_ready.connect(self._on_load_more_finished)
+        worker.failed.connect(self._on_load_more_failed)
+        worker.finished.connect(lambda: self._finishing_search_workers.discard(worker))
+        self._load_more_worker = worker
+        self._finishing_search_workers.add(worker)
+        worker.start()
+        return True
+
+    @Slot(result=bool)
+    def loadPrevious(self) -> bool:
+        if self._loading or self._is_ai_search_mode:
+            return False
+        if self._loaded_offset <= 0 or self._db_path is None:
+            return False
+        page_size = min(_PAGE_SIZE, self._loaded_offset)
+        if page_size <= 0:
+            return False
+        self._loading = True
+        self._page_load_direction = "prepend"
+        worker = SearchPageWorker(
+            self._db_path,
+            self._key,
+            query=self._query_text,
+            page_size=page_size,
+            offset=self._loaded_offset - page_size,
+            sort_by=self._sort_by,
+            ext_filter=self._ext_filter,
+            path_filter=self._current_path_filter(),
+            restrict_to_enabled_folders=(self._folder_repo is not None),
+            marked_only=self._checked_only_filter_active,
+            serial=self._search_serial,
+            date_from=self._date_from,
+            date_to=self._date_to,
+        )
+        worker.results_ready.connect(self._on_load_more_finished)
+        worker.failed.connect(self._on_load_more_failed)
+        worker.finished.connect(lambda: self._finishing_search_workers.discard(worker))
+        self._load_more_worker = worker
+        self._finishing_search_workers.add(worker)
+        worker.start()
+        return True
+
+    def _on_load_more_finished(self, rows: list, serial: int) -> None:
+        self._load_more_worker = None
+        if serial != self._search_serial:
+            self._loading = False
+            return
         results = [
-            SearchResult(image_id=r[0], path=r[1], filename=r[2], metadata_json=r[3], size=r[4], mtime=r[5])
+            SearchResult(
+                image_id=r[0], path=r[1], filename=r[2], metadata_json=r[3],
+                size=r[4], mtime=r[5],
+            )
             for r in rows
         ]
-        self._search_model.append_rows(results)
-        self._loaded_results += len(results)
+        if self._page_load_direction == "prepend":
+            inserted = len(results)
+            self._search_model.prepend_rows(results)
+            self._loaded_offset = max(0, self._loaded_offset - inserted)
+            self._loaded_results += inserted
+            if self._current_result_row >= 0:
+                self._current_result_row += inserted
+                self.currentResultRowChanged.emit()
+                self.currentProxyResultRowChanged.emit()
+        else:
+            self._search_model.append_rows(results)
+            self._loaded_results += len(results)
         self.loadedResultsChanged.emit()
+        self._loading = False
+
+    def _on_load_more_failed(self, error: str) -> None:
+        self._load_more_worker = None
+        _log.error("Load-more failed: %s", error)
         self._loading = False
 
     @Slot(int)
@@ -1674,6 +1916,8 @@ class AppController(QObject):
         for source_row in range(n):
             if self._search_model.get_image_id(source_row) == image_id:
                 self._select_source_row(source_row)
+                if self._pending_browse_jump_id == image_id:
+                    self._pending_browse_jump_id = 0
                 pr = (
                     self._filter_proxy.proxy_row_for(source_row)
                     if self._filter_proxy
@@ -2229,6 +2473,111 @@ class AppController(QObject):
         if self._preview_worker and self._preview_worker.isRunning():
             self._preview_worker.cancel()
 
+    # ── AI-scan ───────────────────────────────────────────────────────────────
+
+    @Slot(int)
+    def aiScanFolder(self, folder_id: int) -> None:
+        """Build the CLIP vector index for every image in *folder_id*.
+
+        No-op while another AI scan is already running — the user must cancel
+        it first.  Progress is reported via the aiScanCurrent / aiScanTotal /
+        aiScanCurrentFile properties.
+        """
+        if self._folder_repo is None or self._is_ai_scanning:
+            return
+        folder = self._folder_repo.get_by_id(folder_id)
+        if folder is None:
+            return
+        self._ai_scan_worker = AiScanWorker(
+            self._db_path,
+            folder_id,
+            folder.path,
+            key=self._key,
+        )
+        self._ai_scan_worker.progress.connect(self._on_ai_scan_progress)
+        self._ai_scan_worker.finished.connect(self._on_ai_scan_finished)
+        self._ai_scan_worker.failed.connect(self._on_ai_scan_failed)
+        self._ai_scan_worker.canceled.connect(self._on_ai_scan_canceled)
+        self._is_ai_scanning = True
+        self._ai_scan_folder_id = folder_id
+        self._ai_scan_current = 0
+        self._ai_scan_total = 0
+        self._ai_scan_current_file = ""
+        self.isAiScanningChanged.emit()
+        self.aiScanFolderIdChanged.emit()
+        self.aiScanCurrentChanged.emit()
+        self.aiScanTotalChanged.emit()
+        self.aiScanCurrentFileChanged.emit()
+        self._ai_scan_worker.start(QThread.Priority.LowPriority)
+
+    @Slot()
+    def cancelAiScan(self) -> None:
+        if self._ai_scan_worker and self._ai_scan_worker.isRunning():
+            self._ai_scan_worker.cancel()
+
+    @Slot(bool)
+    def setAiSearchMode(self, enabled: bool) -> None:
+        if self._is_ai_search_mode == enabled:
+            return
+        self._is_ai_search_mode = enabled
+        self.isAiSearchModeChanged.emit()
+
+    @Slot(str, str)
+    def aiSearch(self, query: str, precision: str = "normal") -> None:
+        """Kick off a CLIP vector search with *query* text."""
+        query = query.strip()
+        if not query or self._db_path is None:
+            return
+        self._last_ai_query = query
+        self._last_ai_precision = precision
+        self._ai_select_first = True
+        self._start_ai_search_worker(query, precision)
+
+    def _start_ai_search_worker(self, query: str, precision: str) -> None:
+        """Internal helper: create and start an AiSearchWorker."""
+        self._search_serial += 1
+        serial = self._search_serial
+        worker = AiSearchWorker(self._db_path, self._key, query, serial, precision=precision)
+        worker.results_ready.connect(self._on_search_finished)
+        worker.failed.connect(self._on_search_failed)
+        worker.finished.connect(lambda: self._finishing_search_workers.discard(worker))
+        self._ai_search_worker = worker
+        self._finishing_search_workers.add(worker)
+        self._search_shows_busy_ui = True
+        self._set_search_busy_ui(True)
+        worker.start()
+
+    def _on_ai_scan_progress(self, done: int, total: int, path: str) -> None:
+        self._ai_scan_current = done
+        self._ai_scan_total = total
+        self._ai_scan_current_file = path
+        self.aiScanCurrentChanged.emit()
+        self.aiScanTotalChanged.emit()
+        self.aiScanCurrentFileChanged.emit()
+
+    def _clear_ai_scan_state(self) -> None:
+        self._is_ai_scanning = False
+        self._ai_scan_folder_id = 0
+        self.isAiScanningChanged.emit()
+        self.aiScanFolderIdChanged.emit()
+
+    def _on_ai_scan_finished(self, indexed: int, errors: int) -> None:
+        self._clear_ai_scan_state()
+        msg = _("AI-Scan complete: {n} image(s) vectorised.").format(n=indexed)
+        if errors:
+            msg += " " + _("{n} file(s) could not be processed.").format(n=errors)
+        self._set_status(msg)
+
+    def _on_ai_scan_failed(self, error: str) -> None:
+        self._clear_ai_scan_state()
+        self._set_status(_("AI-Scan failed: {error}").format(error=error))
+
+    def _on_ai_scan_canceled(self, indexed: int) -> None:
+        self._clear_ai_scan_state()
+        self._set_status(
+            _("AI-Scan canceled ({n} image(s) vectorised so far).").format(n=indexed)
+        )
+
     def _on_preview_progress(self, done: int, total: int, path: str) -> None:
         self._preview_current = done
         self._preview_total = total
@@ -2620,6 +2969,7 @@ class AppController(QObject):
         self.selectedImageSourceChanged.emit()
         self.selectedThumbSourceChanged.emit()
         self.currentResultRowChanged.emit()
+        self.currentProxyResultRowChanged.emit()
         if self._selected_has_preview:
             self._selected_has_preview = False
             self.selectedHasPreviewChanged.emit()

--- a/src/exif_turbo/ui/workers/ai_scan_worker.py
+++ b/src/exif_turbo/ui/workers/ai_scan_worker.py
@@ -1,0 +1,89 @@
+"""Background worker that builds the CLIP vector index for a single folder."""
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from PySide6.QtCore import QThread, Signal
+
+from ...config import ai_id_map_path, ai_index_path
+from ...data.ai_vector_repository import AiVectorRepository
+from ...data.image_index_repository import ImageIndexRepository
+from ...indexing.ai_indexer_service import AiIndexerService, image_paths_for_folder
+
+
+class AiScanWorker(QThread):
+    """Encode all images in a folder with CLIP and persist to the FAISS index.
+
+    Signals mirror those of IndexWorker for consistency:
+      finished(indexed_count, error_count)
+      failed(error_message)
+      progress(done, total, current_path)
+      canceled(indexed_count)
+    """
+
+    finished = Signal(int, int)   # (indexed_count, error_count)
+    failed = Signal(str)
+    progress = Signal(int, int, str)
+    canceled = Signal(int)
+
+    def __init__(
+        self,
+        db_path: Path,
+        folder_id: int,
+        folder_path: str,
+        key: str = "",
+    ) -> None:
+        super().__init__()
+        self._db_path = db_path
+        self._folder_id = folder_id
+        self._folder_path = folder_path
+        self._key = key
+        self._cancel_event = threading.Event()
+
+    def cancel(self) -> None:
+        self._cancel_event.set()
+
+    def run(self) -> None:
+        try:
+            # 1. Collect image paths for the folder from the regular index DB.
+            repo = ImageIndexRepository(self._db_path, key=self._key)
+            stamps = repo.get_folder_stamps(self._folder_id)
+            repo.close()
+            image_paths = image_paths_for_folder(stamps)
+
+            if not image_paths or self._cancel_event.is_set():
+                self.canceled.emit(0)
+                return
+
+            # 2. Load (or create) the FAISS index.
+            idx_path = ai_index_path(self._db_path)
+            map_path = ai_id_map_path(self._db_path)
+            vector_repo = AiVectorRepository(idx_path, map_path)
+            vector_repo.load()
+
+            # 3. Run the CLIP encoder.
+            service = AiIndexerService(vector_repo)
+            indexed_count = 0
+
+            def _on_progress(done: int, total: int, path: str) -> None:
+                nonlocal indexed_count
+                indexed_count = done
+                self.progress.emit(done, total, path)
+
+            indexed, errors = service.build_index(
+                image_paths,
+                on_progress=_on_progress,
+                cancel_check=lambda: self._cancel_event.is_set(),
+            )
+
+            # 4. Persist regardless of cancel so partial work is not lost.
+            vector_repo.save()
+
+            if self._cancel_event.is_set():
+                self.canceled.emit(indexed)
+            else:
+                self.finished.emit(indexed, errors)
+
+        except Exception as exc:  # noqa: BLE001
+            self.failed.emit(str(exc))

--- a/src/exif_turbo/ui/workers/ai_search_worker.py
+++ b/src/exif_turbo/ui/workers/ai_search_worker.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from PySide6.QtCore import QThread, Signal
+
+from ...config import ai_id_map_path, ai_index_path
+from ...data.ai_vector_repository import AiVectorRepository
+from ...data.image_index_repository import ImageIndexRepository
+from ...indexing.ai_indexer_service import AiIndexerService
+
+
+class AiSearchWorker(QThread):
+    """Run a CLIP vector search off the GUI thread.
+
+    Encodes *query_text* with the CLIP text encoder, queries the FAISS index,
+    then hydrates the resulting paths into full image rows from the SQLite DB
+    and emits them through the same ``results_ready`` signal shape as
+    :class:`~exif_turbo.ui.workers.search_worker.SearchWorker` so the
+    controller can reuse ``_on_search_finished`` verbatim.
+
+    Signals
+    -------
+    results_ready(rows, total, format_counts, serial)
+        *rows* is a list of ``(id, path, filename, metadata_json, size, mtime)``
+        tuples ordered by FAISS cosine similarity (highest first).
+        *total* equals ``len(rows)``.
+        *format_counts* is always ``[]`` (no file-type facets in AI mode).
+        *serial* matches the constructor argument.
+    failed(str)
+        Emitted if the search raises an exception.
+    """
+
+    results_ready: Signal = Signal(list, int, list, int)
+    failed: Signal = Signal(str)
+
+    _PRECISION_THRESHOLD: dict[str, float] = {
+        "fine":   0.22,
+        "normal": 0.20,
+        "broad":  0.18,
+    }
+    _CANDIDATE_K = 800  # FAISS candidates fetched before threshold filtering
+
+    def __init__(
+        self,
+        db_path: Path,
+        key: str,
+        query_text: str,
+        serial: int,
+        precision: str = "normal",
+    ) -> None:
+        super().__init__()
+        self._db_path = db_path
+        self._key = key
+        self._query_text = query_text
+        self._serial = serial
+        self._threshold = self._PRECISION_THRESHOLD.get(precision, 0.20)
+
+    def run(self) -> None:
+        try:
+            index_path = ai_index_path(self._db_path)
+            id_map_path = ai_id_map_path(self._db_path)
+
+            vector_repo = AiVectorRepository(index_path, id_map_path)
+            vector_repo.load()
+
+            service = AiIndexerService(vector_repo)
+            query_vec = service.encode_text(self._query_text)
+
+            hits = vector_repo.search(query_vec, top_k=self._CANDIDATE_K, threshold=self._threshold)
+            ranked_paths = [path for path, _score in hits]
+
+            image_repo = ImageIndexRepository(self._db_path, key=self._key)
+            rows = image_repo.get_images_by_paths(ranked_paths)
+
+            self.results_ready.emit(rows, len(rows), [], self._serial)
+        except Exception as exc:  # noqa: BLE001
+            self.failed.emit(str(exc))

--- a/src/exif_turbo/ui/workers/search_worker.py
+++ b/src/exif_turbo/ui/workers/search_worker.py
@@ -94,3 +94,62 @@ class SearchWorker(QThread):
             self.results_ready.emit(rows, total, format_counts, self._serial)
         except Exception as exc:  # noqa: BLE001
             self.failed.emit(str(exc))
+
+
+class SearchPageWorker(QThread):
+    """Load a single page of SQL search results off the GUI thread."""
+
+    results_ready: Signal = Signal(list, int)
+    failed: Signal = Signal(str)
+
+    def __init__(
+        self,
+        db_path: Path,
+        key: str,
+        *,
+        query: str,
+        page_size: int,
+        offset: int,
+        sort_by: str,
+        ext_filter: str,
+        path_filter: List[str] | None,
+        restrict_to_enabled_folders: bool,
+        marked_only: bool,
+        serial: int,
+        date_from: int | None = None,
+        date_to: int | None = None,
+    ) -> None:
+        super().__init__()
+        self._db_path = db_path
+        self._key = key
+        self._query = query
+        self._page_size = page_size
+        self._offset = offset
+        self._sort_by = sort_by
+        self._ext_filter = ext_filter
+        self._path_filter = path_filter
+        self._restrict = restrict_to_enabled_folders
+        self._marked_only = marked_only
+        self._serial = serial
+        self._date_from = date_from
+        self._date_to = date_to
+
+    def run(self) -> None:
+        try:
+            repo = ImageIndexRepository(self._db_path, key=self._key)
+            rows: list = repo.search_images(
+                self._query,
+                self._page_size,
+                self._offset,
+                sort_by=self._sort_by,
+                ext_filter=self._ext_filter,
+                path_filter=self._path_filter,
+                restrict_to_enabled_folders=self._restrict,
+                marked_only=self._marked_only,
+                date_from=self._date_from,
+                date_to=self._date_to,
+            )
+            repo.close()
+            self.results_ready.emit(rows, self._serial)
+        except Exception as exc:  # noqa: BLE001
+            self.failed.emit(str(exc))

--- a/tests/data/test_ai_vector_repository.py
+++ b/tests/data/test_ai_vector_repository.py
@@ -1,0 +1,183 @@
+"""Tests for AiVectorRepository — add, save, load, remove_folder, incremental skip."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from exif_turbo.data.ai_vector_repository import AiVectorRepository, _is_inside
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _random_vec(dim: int = 512) -> np.ndarray:
+    v = np.random.default_rng(0).random((dim,)).astype(np.float32)
+    return (v / np.linalg.norm(v)).astype(np.float32)
+
+
+def _make_repo(tmp_path: Path) -> AiVectorRepository:
+    repo = AiVectorRepository(
+        tmp_path / "ai_index.faiss",
+        tmp_path / "ai_id_map.json",
+    )
+    repo.load()
+    return repo
+
+
+# ── load / save round-trip ────────────────────────────────────────────────────
+
+def test_ai_vector_repository_empty_load_creates_index(tmp_path: Path) -> None:
+    # Arrange / Act
+    repo = _make_repo(tmp_path)
+
+    # Assert
+    assert repo.get_indexed_paths() == set()
+
+
+def test_ai_vector_repository_save_and_reload_preserves_vectors(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    vec = _random_vec()
+    repo.add_images(vec.reshape(1, -1), ["/photos/a.jpg"])
+
+    # Act
+    repo.save()
+    repo2 = _make_repo(tmp_path)
+
+    # Assert
+    assert "/photos/a.jpg" in repo2.get_indexed_paths()
+
+
+# ── add_images ────────────────────────────────────────────────────────────────
+
+def test_ai_vector_repository_add_images_increases_index_size(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    vecs = np.stack([_random_vec() for _ in range(3)])
+    paths = ["/photos/a.jpg", "/photos/b.jpg", "/photos/c.jpg"]
+
+    # Act
+    repo.add_images(vecs, paths)
+
+    # Assert
+    assert repo.get_indexed_paths() == set(paths)
+
+
+def test_ai_vector_repository_add_images_single_vec_without_batch_dim(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+
+    # Act — 1-D vector (shape 512,) should be accepted
+    repo.add_images(_random_vec(), ["/photos/single.jpg"])
+
+    # Assert
+    assert "/photos/single.jpg" in repo.get_indexed_paths()
+
+
+# ── incremental skip ──────────────────────────────────────────────────────────
+
+def test_ai_vector_repository_get_indexed_paths_reflects_added_entries(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    repo.add_images(_random_vec().reshape(1, -1), ["/photos/x.jpg"])
+
+    # Act — caller uses get_indexed_paths() to skip already-vectorised images
+    already = repo.get_indexed_paths()
+
+    # Assert
+    assert "/photos/x.jpg" in already
+    assert "/photos/new.jpg" not in already
+
+
+# ── remove_folder ─────────────────────────────────────────────────────────────
+
+def test_ai_vector_repository_remove_folder_drops_all_paths_in_folder(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    inside = ["/animals/cat.jpg", "/animals/dog.jpg"]
+    outside = ["/photos/x.jpg"]
+    all_paths = inside + outside
+    vecs = np.stack([_random_vec() for _ in all_paths])
+    repo.add_images(vecs, all_paths)
+
+    # Act
+    repo.remove_folder("/animals")
+
+    # Assert
+    remaining = repo.get_indexed_paths()
+    assert remaining == set(outside)
+
+
+def test_ai_vector_repository_remove_folder_noop_when_no_match(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    repo.add_images(_random_vec().reshape(1, -1), ["/photos/a.jpg"])
+
+    # Act
+    repo.remove_folder("/other")
+
+    # Assert — unchanged
+    assert "/photos/a.jpg" in repo.get_indexed_paths()
+
+
+def test_ai_vector_repository_remove_folder_all_entries_empties_index(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    repo.add_images(_random_vec().reshape(1, -1), ["/animals/cat.jpg"])
+
+    # Act
+    repo.remove_folder("/animals")
+
+    # Assert
+    assert repo.get_indexed_paths() == set()
+
+
+# ── search ────────────────────────────────────────────────────────────────────
+
+def test_ai_vector_repository_search_returns_nearest_path(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    query = _random_vec()
+    # Add the query itself (perfect cosine sim = 1.0) plus a random other vec.
+    other = np.random.default_rng(42).random(512).astype(np.float32)
+    other /= np.linalg.norm(other)
+    vecs = np.stack([query, other])
+    repo.add_images(vecs, ["/photos/exact.jpg", "/photos/other.jpg"])
+
+    # Act
+    results = repo.search(query, top_k=2)
+
+    # Assert — exact match is top hit
+    assert results[0][0] == "/photos/exact.jpg"
+    assert results[0][1] == pytest.approx(1.0, abs=1e-5)
+
+
+def test_ai_vector_repository_search_empty_index_returns_empty(tmp_path: Path) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+
+    # Act
+    results = repo.search(_random_vec())
+
+    # Assert
+    assert results == []
+
+
+# ── _is_inside helper ─────────────────────────────────────────────────────────
+
+def test_is_inside_direct_child_returns_true() -> None:
+    assert _is_inside("/photos/cat.jpg", Path("/photos")) is True
+
+
+def test_is_inside_nested_child_returns_true() -> None:
+    assert _is_inside("/photos/2024/cat.jpg", Path("/photos")) is True
+
+
+def test_is_inside_sibling_folder_returns_false() -> None:
+    assert _is_inside("/other/cat.jpg", Path("/photos")) is False
+
+
+def test_is_inside_prefix_overlap_returns_false() -> None:
+    # /photos2 must not match /photos
+    assert _is_inside("/photos2/cat.jpg", Path("/photos")) is False

--- a/tests/data/test_image_index_repository.py
+++ b/tests/data/test_image_index_repository.py
@@ -58,6 +58,28 @@ def test_count_images_after_insert_returns_correct_count(repo: ImageIndexReposit
     assert repo.count_images("") == 5
 
 
+def test_find_image_offset_path_filter_returns_sorted_offset(repo: ImageIndexRepository, tmp_path: Path) -> None:
+    # Arrange
+    folder = tmp_path / "folder"
+    folder.mkdir()
+    for name in ("c.jpg", "a.jpg", "b.jpg"):
+        path = str(make_jpeg(folder / name))
+        repo.upsert_image(path, name, 1.0, 100, {}, name)
+    repo.commit()
+    rows = repo.search_images("", limit=10, offset=0, sort_by="filename_asc")
+    target_id = next(row[0] for row in rows if row[2] == "b.jpg")
+
+    # Act
+    offset = repo.find_image_offset(
+        target_id,
+        sort_by="filename_asc",
+        path_filter=[str(folder)],
+    )
+
+    # Assert
+    assert offset == 1
+
+
 # ── FTS5 search ───────────────────────────────────────────────────────────────
 
 

--- a/tests/indexing/test_ai_indexer_service.py
+++ b/tests/indexing/test_ai_indexer_service.py
@@ -1,0 +1,206 @@
+"""Tests for AiIndexerService — mocks open_clip so torch is not required."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+from exif_turbo.data.ai_vector_repository import AiVectorRepository
+from exif_turbo.indexing.ai_indexer_service import AiIndexerService
+
+
+# ── helpers / fixtures ────────────────────────────────────────────────────────
+
+def _fake_vec() -> np.ndarray:
+    v = np.ones(512, dtype=np.float32)
+    return v / np.linalg.norm(v)
+
+
+def _make_repo(tmp_path: Path) -> AiVectorRepository:
+    repo = AiVectorRepository(
+        tmp_path / "ai_index.faiss",
+        tmp_path / "ai_id_map.json",
+    )
+    repo.load()
+    return repo
+
+
+def _patch_clip(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Patch open_clip and torch so no GPU/download is needed."""
+    import torch  # only used for tensor mocking
+
+    # Fake model
+    fake_model = MagicMock()
+    fake_vecs = torch.from_numpy(
+        np.stack([_fake_vec() for _ in range(32)])
+    ).float()
+    fake_model.encode_image.return_value = fake_vecs
+
+    # Fake preprocess: return a dummy tensor for any image
+    fake_preprocess = MagicMock(return_value=torch.zeros(3, 224, 224))
+
+    # Fake open_clip module
+    fake_open_clip = MagicMock()
+    fake_open_clip.create_model_and_transforms.return_value = (
+        fake_model,
+        MagicMock(),
+        fake_preprocess,
+    )
+
+    monkeypatch.setattr(
+        "exif_turbo.indexing.ai_indexer_service.open_clip",
+        fake_open_clip,
+        raising=False,
+    )
+
+    # Pre-load the model on the service so _ensure_model_loaded is a no-op
+    return fake_model
+
+
+# ── basic indexing ────────────────────────────────────────────────────────────
+
+def test_ai_indexer_service_build_index_vectorises_images(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    sample_dir = Path(__file__).parents[1] / "sample-data" / "computer"
+    image_files = list(sample_dir.glob("*.jpg"))[:2]
+    if not image_files:
+        pytest.skip("No sample images available")
+
+    repo = _make_repo(tmp_path)
+    service = AiIndexerService(repo)
+
+    # Patch torch + open_clip so no model download happens.
+    import torch
+
+    fake_model = MagicMock()
+    fake_model.encode_image.return_value = torch.from_numpy(
+        np.stack([_fake_vec() for _ in image_files])
+    ).float()
+    fake_preprocess = MagicMock(return_value=torch.zeros(3, 224, 224))
+    fake_open_clip = MagicMock()
+    fake_open_clip.create_model_and_transforms.return_value = (
+        fake_model, MagicMock(), fake_preprocess
+    )
+
+    # Act
+    indexed, errors = service.build_index([str(p) for p in image_files])
+
+    # Assert
+    assert indexed == len(image_files)
+    assert errors == 0
+    assert repo.get_indexed_paths() == {str(p) for p in image_files}
+
+
+def test_ai_indexer_service_build_index_skips_already_indexed(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    repo.add_images(_fake_vec().reshape(1, -1), ["/photos/a.jpg"])
+
+    service = AiIndexerService(repo)
+    # _model is None → build_index would call _ensure_model_loaded if there were
+    # pending images.  Since a.jpg is already indexed, it must return (0, 0)
+    # without touching the model at all.
+
+    # Act
+    indexed, errors = service.build_index(["/photos/a.jpg"])
+
+    # Assert
+    assert indexed == 0
+    assert errors == 0
+    assert service._model is None  # model was never loaded
+
+
+def test_ai_indexer_service_build_index_empty_list_returns_zero(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    repo = _make_repo(tmp_path)
+    service = AiIndexerService(repo)
+
+    # Act
+    indexed, errors = service.build_index([])
+
+    # Assert
+    assert (indexed, errors) == (0, 0)
+
+
+# ── cancel ────────────────────────────────────────────────────────────────────
+
+def test_ai_indexer_service_build_index_stops_on_cancel(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import torch
+
+    repo = _make_repo(tmp_path)
+    service = AiIndexerService(repo)
+    fake_model = MagicMock()
+    fake_model.encode_image.return_value = torch.from_numpy(
+        np.stack([_fake_vec() for _ in range(32)])
+    ).float()
+    service._model = fake_model
+    service._preprocess = MagicMock(return_value=torch.zeros(3, 224, 224))
+
+    paths = [f"/photos/img_{i:04d}.jpg" for i in range(100)]
+    # Pretend all files exist by patching PIL.Image.open
+    fake_pil = MagicMock()
+    fake_pil.return_value.__enter__ = lambda s: s
+    fake_pil.return_value.convert.return_value = MagicMock()
+    monkeypatch.setattr("PIL.Image.open", fake_pil, raising=False)
+
+    call_count = [0]
+
+    def _cancel_after_one_batch() -> bool:
+        call_count[0] += 1
+        return call_count[0] > 1  # cancel after first batch
+
+    # Act
+    indexed, errors = service.build_index(
+        paths,
+        cancel_check=_cancel_after_one_batch,
+    )
+
+    # Assert — only one batch (≤32) was processed, not all 100
+    assert indexed <= 32
+
+
+# ── progress callback ─────────────────────────────────────────────────────────
+
+def test_ai_indexer_service_build_index_calls_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    import torch
+
+    repo = _make_repo(tmp_path)
+    service = AiIndexerService(repo)
+    fake_model = MagicMock()
+    fake_model.encode_image.return_value = torch.from_numpy(
+        np.stack([_fake_vec() for _ in range(32)])
+    ).float()
+    service._model = fake_model
+    service._preprocess = MagicMock(return_value=torch.zeros(3, 224, 224))
+
+    paths = [f"/photos/img_{i:04d}.jpg" for i in range(5)]
+    monkeypatch.setattr("PIL.Image.open", MagicMock(return_value=MagicMock()), raising=False)
+
+    progress_calls: List[tuple] = []
+
+    # Act
+    service.build_index(paths, on_progress=lambda d, t, p: progress_calls.append((d, t, p)))
+
+    # Assert — at least one progress call was made
+    assert len(progress_calls) >= 1
+    # Last call should report total == total paths
+    last_done, last_total, _ = progress_calls[-1]
+    assert last_total == len(paths)

--- a/tests/ui/test_app_controller.py
+++ b/tests/ui/test_app_controller.py
@@ -261,6 +261,28 @@ def test_selectResult_thumb_source_updates_synchronously(
     assert len(fired) == 1
 
 
+def test_app_controller_default_ai_disabled(
+    demo_db: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    db_path, _ = demo_db
+    settings_model = SettingsModel(tmp_path / "settings.json")
+    search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+    controller = AppController(
+        db_path,
+        search_model,
+        ExifListModel(),
+        FolderListModel(),
+    )
+
+    # Assert
+    assert settings_model.aiEnabled is False
+    assert controller.aiEnabled is False
+
+    controller.close()
+
+
 def test_selectResult_image_source_is_empty_before_debounce_fires(
     qtbot: QtBot,
     bare_controller: AppController,

--- a/tests/ui/test_browse_navigation.py
+++ b/tests/ui/test_browse_navigation.py
@@ -14,21 +14,34 @@ Run with:
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Generator
+from unittest.mock import patch
 
 import pytest
 from PIL import Image
+from PySide6.QtCore import QPoint, QPointF, Qt, QUrl
+from PySide6.QtQml import QQmlApplicationEngine
+from PySide6.QtQuick import QQuickItem, QQuickWindow
+from PySide6.QtTest import QTest
 from pytestqt.qtbot import QtBot
 
 from exif_turbo.data.image_index_repository import ImageIndexRepository
+from exif_turbo.ui.models.checked_filter_proxy_model import CheckedFilterProxyModel
 from exif_turbo.ui.models.exif_list_model import ExifListModel
 from exif_turbo.ui.models.folder_list_model import FolderListModel
 from exif_turbo.ui.models.search_list_model import SearchListModel
 from exif_turbo.ui.models.settings_model import SettingsModel
+from exif_turbo.ui.providers.preview_image_provider import PreviewImageProvider
+from exif_turbo.ui.providers.raw_image_provider import RawImageProvider
 from exif_turbo.ui.view_models.app_controller import AppController
 
 _PAUSE_MS = 300
+_QML_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "exif_turbo" / "ui" / "qml" / "Main.qml"
+)
 
 # (subdir, filename, PIL format, camera make)
 _IMAGES: list[tuple[str, str, str, str]] = [
@@ -166,6 +179,98 @@ class TestSelectResultById:
 
 
 class TestBrowseNavigation:
+    def test_ai_search_completion_clears_busy_state_and_worker(
+        self,
+        qtbot: QtBot,
+        controller_with_images: tuple[AppController, SearchListModel, Path, Path],
+    ) -> None:
+        # Arrange
+        controller, _, _, _ = controller_with_images
+        controller.setAiSearchMode(True)
+
+        fake_rows = [
+            (1, "C:/images/alpha.jpg", "alpha.jpg", "{}", 123, 1.0),
+        ]
+
+        # Act
+        with patch("exif_turbo.ui.view_models.app_controller.AiSearchWorker.run", autospec=True) as mocked_run:
+            def _emit_results(worker: object) -> None:
+                worker.results_ready.emit(fake_rows, 1, [], worker._serial)  # type: ignore[attr-defined]
+            mocked_run.side_effect = _emit_results
+            with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+                controller.aiSearch("boat", "normal")
+            qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert controller.isSearching is False
+        assert controller._ai_search_worker is None  # type: ignore[attr-defined]
+
+    def test_enter_browse_tab_from_ai_mode_suspends_ai_until_return(
+        self,
+        qtbot: QtBot,
+        controller_with_images: tuple[AppController, SearchListModel, Path, Path],
+    ) -> None:
+        # Arrange
+        controller, search_model, _, folder_b = controller_with_images
+        controller.setAiSearchMode(True)
+        controller._ai_result_cache = list(search_model._rows)  # type: ignore[attr-defined]
+        controller.selectResult(1)
+        qtbot.wait(_PAUSE_MS)
+
+        # Act
+        controller.enterBrowseTab("boats")
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert controller.isAiSearchMode is False
+
+        # Act
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=3000):
+            controller.browseFolder(str(folder_b))
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert controller.isAiSearchMode is False
+
+        # Act
+        controller.leaveBrowseTab()
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert controller.isAiSearchMode is True
+
+    def test_browseFolder_does_not_enable_blocking_search_state(
+        self,
+        qtbot: QtBot,
+        controller_with_images: tuple[AppController, SearchListModel, Path, Path],
+    ) -> None:
+        # Arrange
+        controller, _, _, folder_b = controller_with_images
+        controller.enterBrowseTab("")
+
+        # Act
+        controller.browseFolder(str(folder_b))
+
+        # Assert
+        assert controller.isSearching is False
+
+    def test_browseFolder_with_target_id_enables_busy_search_state(
+        self,
+        qtbot: QtBot,
+        controller_with_images: tuple[AppController, SearchListModel, Path, Path],
+    ) -> None:
+        # Arrange
+        controller, search_model, folder_a, _ = controller_with_images
+        target_id = search_model.get_image_id(0)
+        assert target_id is not None
+        controller.enterBrowseTab("")
+
+        # Act
+        controller.browseFolder(str(folder_a), target_id)
+
+        # Assert
+        assert controller.isSearching is True
+
     def test_selectResultById_after_browseFolder_selects_image_in_browse(
         self,
         qtbot: QtBot,
@@ -194,6 +299,39 @@ class TestBrowseNavigation:
 
         # Assert — the image is found and selected.
         assert proxy_row >= 0
+        assert search_model_path(controller) == target_path
+
+    def test_browse_jump_selection_from_loaded_results_is_not_overwritten(
+        self,
+        qtbot: QtBot,
+        controller_with_images: tuple[AppController, SearchListModel, Path, Path],
+    ) -> None:
+        # Arrange — mimic QML's loadedResultsChanged handler selecting the
+        # target image during a Browse jump.
+        controller, search_model, _, folder_b = controller_with_images
+        target_path = str(folder_b / "epsil.png")
+        target_id: int | None = None
+        for i in range(search_model.rowCount()):
+            if search_model.get_path(i) == target_path:
+                target_id = search_model.get_image_id(i)
+                break
+        assert target_id is not None
+
+        def _apply_pending_jump() -> None:
+            controller.selectResultById(target_id)
+
+        controller.loadedResultsChanged.connect(_apply_pending_jump)
+
+        # Act
+        controller.enterBrowseTab("")
+        controller._pending_browse_jump_id = target_id  # type: ignore[attr-defined]
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=3000):
+            controller.browseFolder(str(folder_b), target_id)
+        qtbot.wait(_PAUSE_MS)
+
+        controller.loadedResultsChanged.disconnect(_apply_pending_jump)
+
+        # Assert — the pending jump selection should survive the search finish.
         assert search_model_path(controller) == target_path
 
     def test_selectResultById_image_not_in_current_browse_folder_returns_minus_one(
@@ -347,15 +485,13 @@ class TestBrowseNavigation:
         assert captured_proxy_row[-1] == expected_proxy_row
         assert search_model.get_path(controller.currentResultRow) == expected_path
 
-    def test_browseFolder_with_target_id_preloads_beyond_first_page(
+    def test_browseFolder_with_target_id_loads_target_page_immediately(
         self,
         qtbot: QtBot,
         tmp_path: Path,
     ) -> None:
-        """browseFolder(folder, target_id) must preload pages until the
-        target image is in the model, even when it falls beyond the first
-        page (page size = 50).  Regression test for the bug where
-        selectResultById always failed because the folder had >50 images.
+        """browseFolder(folder, target_id) should load the slice containing the
+        target image directly instead of paging from row 0.
         """
         from exif_turbo.ui.models.exif_list_model import ExifListModel
         from exif_turbo.ui.models.folder_list_model import FolderListModel
@@ -393,17 +529,79 @@ class TestBrowseNavigation:
             controller.unlock("")
         qtbot.wait(_PAUSE_MS)
 
+        controller.selectResult(10)
+        qtbot.wait(_PAUSE_MS)
+        assert controller.currentResultRow == 10
+
         controller.enterBrowseTab("")
         with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
             controller.browseFolder(str(folder), target_id)
         qtbot.wait(_PAUSE_MS)
 
-        # Act — QML would call this once onLoadedResultsChanged fires.
+        # Act
         proxy_row = controller.selectResultById(target_id)
 
-        # Assert — preloading brought the target into the model.
+        # Assert — the initial Browse slice already contains the target.
         assert proxy_row >= 0
         assert search_model.get_path(controller.currentResultRow) == target_path
+        assert search_model.rowCount() < 50
+
+        controller.close()
+        qtbot.wait(100)
+
+    def test_browseFolder_with_target_id_load_previous_prepends_earlier_rows(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        folder = tmp_path / "large_folder_prev"
+        folder.mkdir()
+
+        repo = ImageIndexRepository(tmp_path / "large_prev.db", key="")
+        for i in range(55):
+            fname = f"img_{i:04d}.jpg"
+            img_path = folder / fname
+            Image.new("RGB", (8, 8)).save(str(img_path), format="JPEG")
+            stat = img_path.stat()
+            repo.upsert_image(str(img_path), fname, stat.st_mtime, stat.st_size, {}, "")
+        repo.commit()
+
+        target_fname = "img_0054.jpg"
+        target_path = str(folder / target_fname)
+        rows = repo.search_images("", 200, 0, sort_by="filename")
+        target_id = next(r[0] for r in rows if r[2] == target_fname)
+        repo.close()
+
+        search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+        controller = AppController(
+            tmp_path / "large_prev.db", search_model,
+            ExifListModel(), FolderListModel(),
+            SettingsModel(tmp_path / "settings.json"),
+        )
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.unlock("")
+        qtbot.wait(_PAUSE_MS)
+
+        controller.enterBrowseTab("")
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.browseFolder(str(folder), target_id)
+        qtbot.wait(_PAUSE_MS)
+
+        initial_first_path = search_model.get_path(0)
+        assert initial_first_path != str(folder / "img_0000.jpg")
+        assert controller.selectResultById(target_id) >= 0
+        assert search_model.get_path(controller.currentResultRow) == target_path
+
+        # Act
+        with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+            controller.loadPrevious()
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert search_model.get_path(0) == str(folder / "img_0000.jpg")
+        assert search_model.get_path(controller.currentResultRow) == target_path
+        assert search_model.rowCount() == 55
 
         controller.close()
         qtbot.wait(100)
@@ -417,3 +615,746 @@ def search_model_path(controller: AppController) -> str | None:
     from exif_turbo.ui.models.search_list_model import SearchListModel
     model: SearchListModel = controller._search_model  # type: ignore[attr-defined]
     return model.get_path(controller.currentResultRow)
+
+
+def click_search_result_browse_button(window: QQuickWindow, results_list: QQuickItem) -> None:
+    """Click the Browse pill on the first visible Search-result card."""
+    click_pos = results_list.mapToScene(
+        QPointF(
+            float(results_list.property("width")) - 72.0,
+            190.0,
+        )
+    )
+    QTest.mouseClick(
+        window,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+        QPoint(int(click_pos.x()), int(click_pos.y())),
+    )
+
+
+@pytest.fixture
+def browse_navigation_window(
+    qtbot: QtBot,
+    controller_with_images: tuple[AppController, SearchListModel, Path, Path],
+) -> Generator[tuple[AppController, SearchListModel, QQmlApplicationEngine, object], None, None]:
+    """Full QML window wired to the existing browse-navigation controller."""
+    controller, search_model, _, _ = controller_with_images
+    exif_model = ExifListModel()
+    folder_model = FolderListModel()
+    settings = SettingsModel(search_model.cache_dir.parent / "qml-settings.json")
+    filter_proxy = CheckedFilterProxyModel()
+    filter_proxy.setSourceModel(search_model)
+    controller.set_filter_proxy(filter_proxy)
+
+    engine = QQmlApplicationEngine()
+    engine.addImageProvider("preview", PreviewImageProvider())
+    engine.addImageProvider("raw", RawImageProvider())
+    ctx = engine.rootContext()
+    ctx.setContextProperty("controller", controller)
+    ctx.setContextProperty("searchModel", search_model)
+    ctx.setContextProperty("filteredSearchModel", filter_proxy)
+    ctx.setContextProperty("exifModel", exif_model)
+    ctx.setContextProperty("folderListModel", folder_model)
+    ctx.setContextProperty("settingsModel", settings)
+    ctx.setContextProperty("thirdPartyLicensesHtml", "")
+    ctx.setContextProperty("userManualUrl", "")
+    engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+    qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+    root = engine.rootObjects()[0]
+
+    yield controller, search_model, engine, root
+
+    engine.deleteLater()
+    qtbot.wait(100)
+
+
+class TestBrowseNavigationQml:
+    def test_entering_browse_tab_does_not_start_blocking_folder_reload(
+        self,
+        qtbot: QtBot,
+        browse_navigation_window: tuple[AppController, SearchListModel, QQmlApplicationEngine, object],
+    ) -> None:
+        # Arrange
+        controller, _, _, root = browse_navigation_window
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        assert tab_bar is not None
+        assert controller.isSearching is False
+
+        # Act
+        tab_bar.setProperty("currentIndex", 1)
+        qtbot.wait(100)
+
+        # Assert
+        assert controller.isSearching is False
+
+    def test_browse_jump_loading_state_hides_browse_content_until_jump_completes(
+        self,
+        qtbot: QtBot,
+        browse_navigation_window: tuple[AppController, SearchListModel, QQmlApplicationEngine, object],
+    ) -> None:
+        # Arrange
+        _, _, _, root = browse_navigation_window
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        busy_overlay = root.findChild(QQuickItem, "searchBusyOverlay")
+        browse_content = root.findChild(QQuickItem, "browseContentSplit")
+        assert tab_bar is not None
+        assert busy_overlay is not None
+        assert browse_content is not None
+
+        tab_bar.setProperty("currentIndex", 1)
+        qtbot.wait(50)
+
+        # Act
+        root.setProperty("_pendingBrowseTargetId", 123)
+        qtbot.wait(10)
+
+        # Assert
+        assert bool(root.property("_browseJumpLoading")) is True
+        assert bool(busy_overlay.property("visible")) is True
+        assert float(browse_content.property("opacity")) == 0.0
+
+        # Act
+        root.setProperty("_pendingBrowseTargetId", -1)
+        root.setProperty("_pendingBrowseScrollRow", 7)
+        qtbot.wait(10)
+
+        # Assert
+        assert bool(root.property("_browseJumpLoading")) is True
+        assert float(browse_content.property("opacity")) == 0.0
+
+        # Act
+        root.setProperty("_pendingBrowseScrollRow", -1)
+        qtbot.wait(10)
+
+        # Assert
+        assert bool(root.property("_browseJumpLoading")) is False
+        assert bool(busy_overlay.property("visible")) is False
+        assert float(browse_content.property("opacity")) == 1.0
+
+    def test_browse_jump_pending_target_retries_until_image_available(
+        self,
+        qtbot: QtBot,
+        browse_navigation_window: tuple[AppController, SearchListModel, QQmlApplicationEngine, object],
+    ) -> None:
+        # Arrange
+        controller, search_model, _, root = browse_navigation_window
+        target_id = search_model.get_image_id(0)
+        target_path = search_model.get_path(0)
+        assert target_id is not None
+        assert target_path is not None
+
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        assert tab_bar is not None
+        tab_bar.setProperty("currentIndex", 1)
+        qtbot.wait(50)
+
+        saved_rows = list(search_model._rows)  # type: ignore[attr-defined]
+        search_model.set_rows([])
+        root.setProperty("_pendingBrowseTargetId", target_id)
+
+        # Act
+        controller.loadedResultsChanged.emit()
+        qtbot.wait(50)
+
+        # Assert
+        assert root.property("_pendingBrowseTargetId") == target_id
+
+        # Arrange
+        search_model.set_rows(saved_rows)
+
+        # Act
+        controller.loadedResultsChanged.emit()
+        qtbot.wait(100)
+
+        # Assert
+        assert root.property("_pendingBrowseTargetId") == -1
+        assert search_model.get_path(controller.currentResultRow) == target_path
+
+    def test_browse_jump_scrolls_large_folder_to_target_row(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        folder = tmp_path / "large_folder"
+        folder.mkdir()
+
+        repo = ImageIndexRepository(tmp_path / "large_qml.db", key="")
+        for i in range(55):
+            fname = f"img_{i:04d}.jpg"
+            img_path = folder / fname
+            Image.new("RGB", (8, 8)).save(str(img_path), format="JPEG")
+            stat = img_path.stat()
+            repo.upsert_image(str(img_path), fname, stat.st_mtime, stat.st_size, {}, "")
+        repo.commit()
+        rows = repo.search_images("", 200, 0, sort_by="filename")
+        target_fname = "img_0054.jpg"
+        target_row = next(r for r in rows if r[2] == target_fname)
+        target_id = target_row[0]
+        target_path = target_row[1]
+        repo.close()
+
+        search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+        exif_model = ExifListModel()
+        folder_model = FolderListModel()
+        settings = SettingsModel(tmp_path / "qml-settings.json")
+        controller = AppController(
+            tmp_path / "large_qml.db",
+            search_model,
+            exif_model,
+            folder_model,
+            settings,
+        )
+        filter_proxy = CheckedFilterProxyModel()
+        filter_proxy.setSourceModel(search_model)
+        controller.set_filter_proxy(filter_proxy)
+
+        engine = QQmlApplicationEngine()
+        engine.addImageProvider("preview", PreviewImageProvider())
+        engine.addImageProvider("raw", RawImageProvider())
+        ctx = engine.rootContext()
+        ctx.setContextProperty("controller", controller)
+        ctx.setContextProperty("searchModel", search_model)
+        ctx.setContextProperty("filteredSearchModel", filter_proxy)
+        ctx.setContextProperty("exifModel", exif_model)
+        ctx.setContextProperty("folderListModel", folder_model)
+        ctx.setContextProperty("settingsModel", settings)
+        ctx.setContextProperty("thirdPartyLicensesHtml", "")
+        ctx.setContextProperty("userManualUrl", "")
+        engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+        qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+        root = engine.rootObjects()[0]
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        browse_list = root.findChild(QQuickItem, "browseImageList")
+        assert tab_bar is not None
+        assert browse_list is not None
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.unlock("")
+        qtbot.wait(_PAUSE_MS)
+
+        root.setProperty("_pendingBrowseTargetId", target_id)
+
+        # Act
+        tab_bar.setProperty("currentIndex", 1)
+        controller.browseFolder(str(folder), target_id)
+        qtbot.waitUntil(lambda: root.property("_pendingBrowseTargetId") == -1, timeout=5000)
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert search_model.get_path(controller.currentResultRow) == target_path
+        assert browse_list.property("currentIndex") == controller.currentProxyResultRow
+        assert float(browse_list.property("contentY")) > 0.0
+
+        engine.deleteLater()
+        controller.close()
+        qtbot.wait(100)
+
+    def test_browse_button_click_large_folder_opens_target_slice(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        folder = tmp_path / "large_folder_search"
+        folder.mkdir()
+
+        target_fname = "img_0054.jpg"
+        target_path = str(folder / target_fname)
+        repo = ImageIndexRepository(tmp_path / "large_qml_search.db", key="")
+        for i in range(55):
+            fname = f"img_{i:04d}.jpg"
+            img_path = folder / fname
+            Image.new("RGB", (8, 8)).save(str(img_path), format="JPEG")
+            stat = img_path.stat()
+            text = fname
+            if fname == target_fname:
+                text = f"{fname} needle"
+            repo.upsert_image(str(img_path), fname, stat.st_mtime, stat.st_size, {}, text)
+        repo.commit()
+        repo.close()
+
+        search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+        exif_model = ExifListModel()
+        folder_model = FolderListModel()
+        settings = SettingsModel(tmp_path / "qml-search-settings.json")
+        controller = AppController(
+            tmp_path / "large_qml_search.db",
+            search_model,
+            exif_model,
+            folder_model,
+            settings,
+        )
+        filter_proxy = CheckedFilterProxyModel()
+        filter_proxy.setSourceModel(search_model)
+        controller.set_filter_proxy(filter_proxy)
+
+        engine = QQmlApplicationEngine()
+        engine.addImageProvider("preview", PreviewImageProvider())
+        engine.addImageProvider("raw", RawImageProvider())
+        ctx = engine.rootContext()
+        ctx.setContextProperty("controller", controller)
+        ctx.setContextProperty("searchModel", search_model)
+        ctx.setContextProperty("filteredSearchModel", filter_proxy)
+        ctx.setContextProperty("exifModel", exif_model)
+        ctx.setContextProperty("folderListModel", folder_model)
+        ctx.setContextProperty("settingsModel", settings)
+        ctx.setContextProperty("thirdPartyLicensesHtml", "")
+        ctx.setContextProperty("userManualUrl", "")
+        engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+        qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+        root = engine.rootObjects()[0]
+        qml_window: QQuickWindow = root  # type: ignore[assignment]
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        results_list = root.findChild(QQuickItem, "resultsList")
+        browse_list = root.findChild(QQuickItem, "browseImageList")
+        assert tab_bar is not None
+        assert results_list is not None
+        assert browse_list is not None
+
+        qml_window.setVisible(True)
+        try:
+            qtbot.waitExposed(qml_window, timeout=3000)
+        except Exception:
+            qtbot.wait(100)
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.unlock("")
+        qtbot.wait(_PAUSE_MS)
+
+        # Act
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.search("needle")
+        qtbot.wait(_PAUSE_MS)
+        assert search_model.rowCount() == 1
+
+        click_search_result_browse_button(qml_window, results_list)
+        qtbot.waitUntil(lambda: tab_bar.property("currentIndex") == 1, timeout=5000)
+        qtbot.waitUntil(lambda: root.property("_pendingBrowseTargetId") == -1, timeout=5000)
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert controller.totalResults == 55
+        assert search_model.get_path(controller.currentResultRow) == target_path
+        assert browse_list.property("currentIndex") == controller.currentProxyResultRow
+        assert float(browse_list.property("contentY")) > 0.0
+        assert search_model.rowCount() < controller.totalResults
+
+        engine.deleteLater()
+        controller.close()
+        qtbot.wait(100)
+
+    def test_ai_browse_button_click_large_folder_opens_target_slice(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        folder = tmp_path / "large_folder_ai"
+        folder.mkdir()
+
+        target_fname = "img_0054.jpg"
+        repo = ImageIndexRepository(tmp_path / "large_qml_ai.db", key="")
+        for i in range(55):
+            fname = f"img_{i:04d}.jpg"
+            img_path = folder / fname
+            Image.new("RGB", (8, 8)).save(str(img_path), format="JPEG")
+            stat = img_path.stat()
+            repo.upsert_image(str(img_path), fname, stat.st_mtime, stat.st_size, {}, fname)
+        repo.commit()
+        rows = repo.search_images("", 200, 0, sort_by="filename")
+        target_row = next(row for row in rows if row[2] == target_fname)
+        target_path = target_row[1]
+        repo.close()
+
+        search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+        exif_model = ExifListModel()
+        folder_model = FolderListModel()
+        settings = SettingsModel(tmp_path / "qml-ai-settings.json")
+        controller = AppController(
+            tmp_path / "large_qml_ai.db",
+            search_model,
+            exif_model,
+            folder_model,
+            settings,
+        )
+        filter_proxy = CheckedFilterProxyModel()
+        filter_proxy.setSourceModel(search_model)
+        controller.set_filter_proxy(filter_proxy)
+
+        engine = QQmlApplicationEngine()
+        engine.addImageProvider("preview", PreviewImageProvider())
+        engine.addImageProvider("raw", RawImageProvider())
+        ctx = engine.rootContext()
+        ctx.setContextProperty("controller", controller)
+        ctx.setContextProperty("searchModel", search_model)
+        ctx.setContextProperty("filteredSearchModel", filter_proxy)
+        ctx.setContextProperty("exifModel", exif_model)
+        ctx.setContextProperty("folderListModel", folder_model)
+        ctx.setContextProperty("settingsModel", settings)
+        ctx.setContextProperty("thirdPartyLicensesHtml", "")
+        ctx.setContextProperty("userManualUrl", "")
+        engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+        qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+        root = engine.rootObjects()[0]
+        qml_window: QQuickWindow = root  # type: ignore[assignment]
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        results_list = root.findChild(QQuickItem, "resultsList")
+        browse_list = root.findChild(QQuickItem, "browseImageList")
+        assert tab_bar is not None
+        assert results_list is not None
+        assert browse_list is not None
+
+        qml_window.setVisible(True)
+        try:
+            qtbot.waitExposed(qml_window, timeout=3000)
+        except Exception:
+            qtbot.wait(100)
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.unlock("")
+        qtbot.wait(_PAUSE_MS)
+
+        root.setProperty("_aiSearchMode", True)
+        controller.setAiSearchMode(True)
+
+        with patch("exif_turbo.ui.view_models.app_controller.AiSearchWorker.run", autospec=True) as mocked_run:
+            def _emit_results(worker: object) -> None:
+                worker.results_ready.emit([target_row], 1, [], worker._serial)  # type: ignore[attr-defined]
+
+            mocked_run.side_effect = _emit_results
+
+            # Act
+            with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+                controller.aiSearch("needle", "normal")
+            qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert controller.isAiSearchMode is True
+        assert search_model.rowCount() == 1
+        assert search_model.get_path(controller.currentResultRow) == target_path
+
+        # Act
+        click_search_result_browse_button(qml_window, results_list)
+        qtbot.waitUntil(lambda: tab_bar.property("currentIndex") == 1, timeout=5000)
+        qtbot.waitUntil(lambda: root.property("_pendingBrowseTargetId") == -1, timeout=5000)
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert controller.isAiSearchMode is False
+        assert controller.totalResults == 55
+        assert search_model.get_path(controller.currentResultRow) == target_path
+        assert browse_list.property("currentIndex") == controller.currentProxyResultRow
+        assert float(browse_list.property("contentY")) > 0.0
+        assert search_model.rowCount() < controller.totalResults
+
+        # Act
+        with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+            tab_bar.setProperty("currentIndex", 0)
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert controller.isAiSearchMode is True
+        assert search_model.rowCount() == 1
+        assert search_model.get_path(controller.currentResultRow) == target_path
+
+        engine.deleteLater()
+        controller.close()
+        qtbot.wait(100)
+
+    def test_browse_jump_upward_scroll_prefetches_previous_page_before_top_reached(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        folder = tmp_path / "large_folder_upscroll"
+        folder.mkdir()
+
+        repo = ImageIndexRepository(tmp_path / "large_qml_upscroll.db", key="")
+        for i in range(55):
+            fname = f"img_{i:04d}.jpg"
+            img_path = folder / fname
+            Image.new("RGB", (8, 8)).save(str(img_path), format="JPEG")
+            stat = img_path.stat()
+            repo.upsert_image(str(img_path), fname, stat.st_mtime, stat.st_size, {}, "")
+        repo.commit()
+        rows = repo.search_images("", 200, 0, sort_by="filename")
+        target_row = next(r for r in rows if r[2] == "img_0054.jpg")
+        target_id = target_row[0]
+        target_path = target_row[1]
+        repo.close()
+
+        search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+        exif_model = ExifListModel()
+        folder_model = FolderListModel()
+        settings = SettingsModel(tmp_path / "qml-upscroll-settings.json")
+        controller = AppController(
+            tmp_path / "large_qml_upscroll.db",
+            search_model,
+            exif_model,
+            folder_model,
+            settings,
+        )
+        filter_proxy = CheckedFilterProxyModel()
+        filter_proxy.setSourceModel(search_model)
+        controller.set_filter_proxy(filter_proxy)
+
+        engine = QQmlApplicationEngine()
+        engine.addImageProvider("preview", PreviewImageProvider())
+        engine.addImageProvider("raw", RawImageProvider())
+        ctx = engine.rootContext()
+        ctx.setContextProperty("controller", controller)
+        ctx.setContextProperty("searchModel", search_model)
+        ctx.setContextProperty("filteredSearchModel", filter_proxy)
+        ctx.setContextProperty("exifModel", exif_model)
+        ctx.setContextProperty("folderListModel", folder_model)
+        ctx.setContextProperty("settingsModel", settings)
+        ctx.setContextProperty("thirdPartyLicensesHtml", "")
+        ctx.setContextProperty("userManualUrl", "")
+        engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+        qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+        root = engine.rootObjects()[0]
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        browse_list = root.findChild(QQuickItem, "browseImageList")
+        assert tab_bar is not None
+        assert browse_list is not None
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.unlock("")
+        qtbot.wait(_PAUSE_MS)
+
+        root.setProperty("_pendingBrowseTargetId", target_id)
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            tab_bar.setProperty("currentIndex", 1)
+            controller.browseFolder(str(folder), target_id)
+        qtbot.waitUntil(lambda: root.property("_pendingBrowseTargetId") == -1, timeout=5000)
+        qtbot.wait(_PAUSE_MS)
+
+        initial_count = search_model.rowCount()
+        assert initial_count < controller.totalResults
+        assert float(browse_list.property("contentY")) > 0.0
+        initial_content_y = float(browse_list.property("contentY"))
+
+        # Act
+        with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+            browse_list.setProperty("contentY", initial_content_y - 1.0)
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert search_model.rowCount() > initial_count
+        assert search_model.get_path(controller.currentResultRow) == target_path
+        assert float(browse_list.property("contentY")) > 0.0
+
+        engine.deleteLater()
+        controller.close()
+        qtbot.wait(100)
+
+    def test_browse_downward_scroll_prefetches_next_page_before_bottom_reached(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        folder = tmp_path / "large_folder_downprefetch"
+        folder.mkdir()
+
+        repo = ImageIndexRepository(tmp_path / "large_qml_downprefetch.db", key="")
+        for i in range(180):
+            fname = f"img_{i:04d}.jpg"
+            img_path = folder / fname
+            Image.new("RGB", (8, 8)).save(str(img_path), format="JPEG")
+            stat = img_path.stat()
+            repo.upsert_image(str(img_path), fname, stat.st_mtime, stat.st_size, {}, "")
+        repo.commit()
+        repo.close()
+
+        search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+        exif_model = ExifListModel()
+        folder_model = FolderListModel()
+        settings = SettingsModel(tmp_path / "qml-downprefetch-settings.json")
+        controller = AppController(
+            tmp_path / "large_qml_downprefetch.db",
+            search_model,
+            exif_model,
+            folder_model,
+            settings,
+        )
+        filter_proxy = CheckedFilterProxyModel()
+        filter_proxy.setSourceModel(search_model)
+        controller.set_filter_proxy(filter_proxy)
+
+        engine = QQmlApplicationEngine()
+        engine.addImageProvider("preview", PreviewImageProvider())
+        engine.addImageProvider("raw", RawImageProvider())
+        ctx = engine.rootContext()
+        ctx.setContextProperty("controller", controller)
+        ctx.setContextProperty("searchModel", search_model)
+        ctx.setContextProperty("filteredSearchModel", filter_proxy)
+        ctx.setContextProperty("exifModel", exif_model)
+        ctx.setContextProperty("folderListModel", folder_model)
+        ctx.setContextProperty("settingsModel", settings)
+        ctx.setContextProperty("thirdPartyLicensesHtml", "")
+        ctx.setContextProperty("userManualUrl", "")
+        engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+        qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+        root = engine.rootObjects()[0]
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        browse_list = root.findChild(QQuickItem, "browseImageList")
+        assert tab_bar is not None
+        assert browse_list is not None
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.unlock("")
+        qtbot.wait(_PAUSE_MS)
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            tab_bar.setProperty("currentIndex", 1)
+            controller.browseFolder(str(folder))
+        qtbot.wait(_PAUSE_MS)
+
+        with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+            controller.loadMore()
+        qtbot.wait(_PAUSE_MS)
+
+        initial_count = search_model.rowCount()
+        assert initial_count == 100
+        assert float(browse_list.property("contentY")) == 0.0
+
+        row_height = int(root.property("_browseRowHeight"))
+        visible_rows = max(
+            1,
+            math.ceil(float(browse_list.property("height")) / row_height),
+        )
+        before_prefetch_row = max(0, 49 - visible_rows)
+        prefetch_row = max(0, 50 - visible_rows)
+
+        # Act
+        browse_list.setProperty("contentY", float(before_prefetch_row * row_height))
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert search_model.rowCount() == initial_count
+
+        # Act
+        with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+            browse_list.setProperty("contentY", float(prefetch_row * row_height))
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert search_model.rowCount() == initial_count + 50
+        assert float(browse_list.property("contentY")) > 0.0
+
+        engine.deleteLater()
+        controller.close()
+        qtbot.wait(100)
+
+    def test_browse_down_arrow_prefetches_next_page_before_loaded_end(
+        self,
+        qtbot: QtBot,
+        tmp_path: Path,
+    ) -> None:
+        # Arrange
+        folder = tmp_path / "large_folder_downkeyprefetch"
+        folder.mkdir()
+
+        repo = ImageIndexRepository(tmp_path / "large_qml_downkeyprefetch.db", key="")
+        for i in range(180):
+            fname = f"img_{i:04d}.jpg"
+            img_path = folder / fname
+            Image.new("RGB", (8, 8)).save(str(img_path), format="JPEG")
+            stat = img_path.stat()
+            repo.upsert_image(str(img_path), fname, stat.st_mtime, stat.st_size, {}, "")
+        repo.commit()
+        repo.close()
+
+        search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+        exif_model = ExifListModel()
+        folder_model = FolderListModel()
+        settings = SettingsModel(tmp_path / "qml-downkeyprefetch-settings.json")
+        controller = AppController(
+            tmp_path / "large_qml_downkeyprefetch.db",
+            search_model,
+            exif_model,
+            folder_model,
+            settings,
+        )
+        filter_proxy = CheckedFilterProxyModel()
+        filter_proxy.setSourceModel(search_model)
+        controller.set_filter_proxy(filter_proxy)
+
+        engine = QQmlApplicationEngine()
+        engine.addImageProvider("preview", PreviewImageProvider())
+        engine.addImageProvider("raw", RawImageProvider())
+        ctx = engine.rootContext()
+        ctx.setContextProperty("controller", controller)
+        ctx.setContextProperty("searchModel", search_model)
+        ctx.setContextProperty("filteredSearchModel", filter_proxy)
+        ctx.setContextProperty("exifModel", exif_model)
+        ctx.setContextProperty("folderListModel", folder_model)
+        ctx.setContextProperty("settingsModel", settings)
+        ctx.setContextProperty("thirdPartyLicensesHtml", "")
+        ctx.setContextProperty("userManualUrl", "")
+        engine.load(QUrl.fromLocalFile(str(_QML_PATH)))
+
+        qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5000)
+        root = engine.rootObjects()[0]
+        qml_window: QQuickWindow = root  # type: ignore[assignment]
+        tab_bar = root.findChild(QQuickItem, "mainTabBar")
+        browse_list = root.findChild(QQuickItem, "browseImageList")
+        assert tab_bar is not None
+        assert browse_list is not None
+
+        qml_window.setVisible(True)
+        try:
+            qtbot.waitExposed(qml_window, timeout=3000)
+        except Exception:
+            qtbot.wait(100)
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            controller.unlock("")
+        qtbot.wait(_PAUSE_MS)
+
+        with qtbot.waitSignal(controller.totalResultsChanged, timeout=5000):
+            tab_bar.setProperty("currentIndex", 1)
+            controller.browseFolder(str(folder))
+        qtbot.wait(_PAUSE_MS)
+
+        with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+            controller.loadMore()
+        qtbot.wait(_PAUSE_MS)
+
+        initial_count = search_model.rowCount()
+        assert initial_count == 100
+
+        row_height = int(root.property("_browseRowHeight"))
+        visible_rows = max(
+            1,
+            math.ceil(float(browse_list.property("height")) / row_height),
+        )
+        controller.selectResult(48)
+        browse_list.setProperty("contentY", float(max(0, 49 - visible_rows) * row_height))
+        qml_window.requestActivate()
+        browse_list.setProperty("focus", True)
+        qtbot.wait(_PAUSE_MS)
+
+        # Act
+        with qtbot.waitSignal(controller.loadedResultsChanged, timeout=5000):
+            QTest.keyClick(qml_window, Qt.Key.Key_Down)
+        qtbot.wait(_PAUSE_MS)
+
+        # Assert
+        assert search_model.rowCount() == initial_count + 50
+        assert controller.currentResultRow == 49
+
+        engine.deleteLater()
+        controller.close()
+        qtbot.wait(100)


### PR DESCRIPTION
## Summary
- add AI vector indexing, search, and scan support with repository, worker, and test coverage
- fix Search and AI Search to Browse jumps for large folders, including direct target-page loading, bidirectional infinite scrolling, one-page-ahead prefetch for wheel and keyboard navigation, and a loading veil during Browse jumps
- default AI features to off for fresh settings and controller fallback, and ignore local pytest and temp artifacts

## Testing
- .\.venv\Scripts\python.exe -m pytest tests/ui/test_browse_navigation.py -q
- .\.venv\Scripts\python.exe -m pytest tests/ui/test_browse_wheel_scroll.py -q
- .\.venv\Scripts\python.exe -m pytest tests/ui/test_app_controller.py -q
