### PR TITLE
Fix browse prefetch and AI rescan test issues

### DIFF
--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -193,6 +193,8 @@ ApplicationWindow {
         // Called after every search finishes (Browse folder load or Search tab restore).
         // Called after every search finishes (Browse folder load or Search tab restore).
         function onLoadedResultsChanged() {
+            // A prefetch page (if any) has landed; allow the next one.
+            root._browsePrefetchInFlight = false
             // Browse tab: jump to the pending target image once folder results are loaded.
             if (mainTabBar.currentIndex === 1 && root._pendingBrowseTargetId !== -1) {
                 root._applyPendingBrowseJump()
@@ -361,6 +363,13 @@ ApplicationWindow {
     readonly property int _browseRowHeight: 210
     property real   _lastBrowseContentY: 0.0
     property bool   _suspendBrowsePrefetch: false
+    // Guards against issuing more than one prefetch page per directional step.
+    // A single Key_Down both scrolls the list (triggering onContentYChanged)
+    // and schedules an explicit directional prefetch; without this flag both
+    // paths call loadMore(), and the controller's pending-request replay turns
+    // that into two appended pages instead of one.  Cleared on the next
+    // loadedResultsChanged once the in-flight page has landed.
+    property bool   _browsePrefetchInFlight: false
     // One-shot flag: restore resultsList position after the next search load
     property bool   _restoreSearchPosition: false
     property int    _searchRestoreAttempts: 0
@@ -508,7 +517,10 @@ ApplicationWindow {
         var remainingRowsBelow = browseImageList.count - 1 - lastVisibleRow
         if (remainingRowsBelow > root._browsePageSize)
             return
-        controller.loadMore()
+        if (root._browsePrefetchInFlight)
+            return
+        if (controller.loadMore())
+            root._browsePrefetchInFlight = true
     }
 
     // ── Dialogs ───────────────────────────────────────────────────────────

--- a/tests/ui/test_ai_scan_worker.py
+++ b/tests/ui/test_ai_scan_worker.py
@@ -68,7 +68,7 @@ class _FakeAiIndexerService:
         self._preview_cache_dir = preview_cache_dir
         self._preview_cache_key = preview_cache_key
 
-    def build_index(self, image_paths, on_progress=None, cancel_check=None):  # type: ignore[no-untyped-def]
+    def build_index(self, image_paths, stamps=None, on_progress=None, cancel_check=None):  # type: ignore[no-untyped-def]
         pending = [p for p in image_paths if p not in self._repo.get_indexed_paths()]
         if pending:
             vec = np.ones((len(pending), 512), dtype=np.float32)


### PR DESCRIPTION
Addressed a bug where a single Key_Down event triggered multiple prefetch requests, leading to incorrect page loading. Implemented a guard to ensure only one prefetch occurs per scroll step. Also fixed a TypeError in the AI rescan test by aligning the fake indexer's method signature with the real one.