### PR TITLE
Add configurable JSON export formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Fully generated using VS Code Copilot.
 - Encrypted database at rest (SQLCipher); passphrase set on first launch, unlocked via the UI
 - **Mark / select images** — select all results (or deselect all) with a single menu action; individual checkbox per result row
 - **Select images without thumbnail** — `Select → Select Images Without Thumbnail` marks every result whose thumbnail is not yet cached on disk (including images the thumbnailer permanently gave up on), so they can be exported, deleted or rescanned in bulk
-- **Export marked images as JSON** — exports EXIF metadata for all marked images to a JSON file, respecting the current UI sort order
+- **Export marked images as JSON** — exports EXIF metadata for all marked images to a JSON file, respecting the current UI sort order; the output format is configurable in **Settings → JSON Export Formatting** (compact one-record-per-line by default, or pretty-printed with tabs or a chosen number of spaces)
 - **Delete marked images** — `Action → Delete Marked Images…` permanently removes every marked image from disk *and* from the index, including any cached thumbnail and rendered preview; a confirmation dialog requires you to type the exact count to proceed
 - **Bulk-op progress overlay** — modal overlay with a progress bar and live `X / Y` count during select-all, deselect-all, and export operations; cancelable at any time
 - **Unlock spinner** — animated indicator shown on the lock screen while the encrypted database is being opened

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -736,7 +736,7 @@ database — not just the visible results.
 
 | Action | What it does |
 |--------|--------------|
-| **Export Metadata as JSON…** | Writes the EXIF metadata of every marked image to a JSON file you choose via a Save dialog. The export honours the current **Sort** order (date taken, filename, path, or size). When nothing is marked, the menu label changes to *"Export Metadata as JSON… (all results)"* and the action exports every image matching the current filters instead. |
+| **Export Metadata as JSON…** | Writes the EXIF metadata of every marked image to a JSON file you choose via a Save dialog. The export honours the current **Sort** order (date taken, filename, path, or size). When nothing is marked, the menu label changes to *"Export Metadata as JSON… (all results)"* and the action exports every image matching the current filters instead. The on-disk layout is controlled by **Settings → JSON Export Formatting** (see *Settings*). |
 | **Delete Marked Images…** | Permanently deletes every marked image **from disk** and removes its row from the index. Cached thumbnails (`.png` / `.enc`), `.skip` sentinels, and any rendered preview (`.jpg` / `.jpg.enc`) for the deleted images are also cleaned up. Disabled when nothing is marked. The menu label includes the current count, e.g. *"Delete Marked Images… (12 selected)"*. |
 
 Both menu items report the live count in their label and run via the bulk-op
@@ -804,6 +804,20 @@ full paths.
 Examples: `@eaDir`, `*.tmp`, `Thumbs.db`
 
 Changes to the blacklist take effect on the next rescan.
+
+### JSON Export Formatting
+
+Controls how the **Export Metadata as JSON…** action writes its output.
+
+- **Pretty-print (indented) JSON** — off by default, which keeps the historical
+  compact layout (the export is a JSON array with each record serialised on its
+  own line). Turn it on to indent every record for easier human reading.
+- **Indent style** — when pretty-printing is on, choose **Spaces** or **Tabs**.
+- **Indent size** — when the style is **Spaces**, choose how many spaces make up
+  one indentation level (2, 4, or 8).
+
+Whatever the format, the file is always valid JSON that round-trips back to the
+same records. The setting is stored per database and applies to the next export.
 
 ### Theme
 

--- a/src/exif_turbo/ui/models/settings_model.py
+++ b/src/exif_turbo/ui/models/settings_model.py
@@ -10,6 +10,7 @@ from typing import List
 from PySide6.QtCore import Property, QObject, Signal, Slot
 
 from exif_turbo.i18n import _, apply_language, available_languages, current_theme, set_theme
+from exif_turbo.utils.json_export import JsonExportFormat
 
 
 _CPU_COUNT = os.cpu_count() or 2
@@ -40,6 +41,16 @@ _VALID_SORTS = {
     "captured_desc", "captured_asc",
 }
 
+# JSON export formatting defaults — compact (one record per line) keeps the
+# historical output unchanged unless the user opts in to pretty-printing.
+_DEFAULT_JSON_PRETTY = False
+_VALID_INDENT_STYLES = {"space", "tab"}
+_DEFAULT_JSON_INDENT_STYLE = "space"
+_DEFAULT_JSON_INDENT_SIZE = 2
+_JSON_INDENT_SIZE_CHOICES: List[int] = [2, 4, 8]
+_MIN_JSON_INDENT_SIZE = 1
+_MAX_JSON_INDENT_SIZE = 8
+
 _IS_MACOS_INTEL = sys.platform == "darwin" and platform.machine().lower() in {"x86_64", "amd64"}
 _AI_FEATURE_SUPPORTED = not _IS_MACOS_INTEL
 _AI_UNAVAILABLE_REASON = _("PyTorch is not available on macOS Intel for Python 3.13+.")
@@ -62,6 +73,7 @@ class SettingsModel(QObject):
     previewMaxSizeChanged = Signal()
     sortByChanged = Signal()
     aiEnabledChanged = Signal()
+    jsonExportFormatChanged = Signal()
 
     def __init__(self, settings_path: Path, parent: QObject | None = None) -> None:
         super().__init__(parent)
@@ -73,6 +85,9 @@ class SettingsModel(QObject):
         self._preview_max_size: int = _DEFAULT_PREVIEW_SIZE
         self._sort_by: str = _DEFAULT_SORT
         self._ai_enabled: bool = False
+        self._json_pretty: bool = _DEFAULT_JSON_PRETTY
+        self._json_indent_style: str = _DEFAULT_JSON_INDENT_STYLE
+        self._json_indent_size: int = _DEFAULT_JSON_INDENT_SIZE
         self._load()
 
     # ── Properties ───────────────────────────────────────────────────────────
@@ -241,6 +256,58 @@ class SettingsModel(QObject):
         self.sortByChanged.emit()
         self._save()
 
+    # ── JSON export formatting ────────────────────────────────────────────────
+
+    @Property(bool, notify=jsonExportFormatChanged)
+    def jsonExportPretty(self) -> bool:
+        return self._json_pretty
+
+    @Slot(bool)
+    def setJsonExportPretty(self, value: bool) -> None:
+        if self._json_pretty == value:
+            return
+        self._json_pretty = value
+        self.jsonExportFormatChanged.emit()
+        self._save()
+
+    @Property(str, notify=jsonExportFormatChanged)
+    def jsonExportIndentStyle(self) -> str:
+        return self._json_indent_style
+
+    @Slot(str)
+    def setJsonExportIndentStyle(self, value: str) -> None:
+        if value not in _VALID_INDENT_STYLES or self._json_indent_style == value:
+            return
+        self._json_indent_style = value
+        self.jsonExportFormatChanged.emit()
+        self._save()
+
+    @Property(int, notify=jsonExportFormatChanged)
+    def jsonExportIndentSize(self) -> int:
+        return self._json_indent_size
+
+    @Property("QVariantList", constant=True)
+    def jsonExportIndentSizeChoices(self) -> List[int]:
+        return list(_JSON_INDENT_SIZE_CHOICES)
+
+    @Slot(int)
+    def setJsonExportIndentSize(self, value: int) -> None:
+        clamped = max(_MIN_JSON_INDENT_SIZE, min(_MAX_JSON_INDENT_SIZE, value))
+        if self._json_indent_size == clamped:
+            return
+        self._json_indent_size = clamped
+        self.jsonExportFormatChanged.emit()
+        self._save()
+
+    @property
+    def json_export_format(self) -> JsonExportFormat:
+        """Python-only accessor for AppController — the current export format."""
+        return JsonExportFormat(
+            pretty=self._json_pretty,
+            indent_style=self._json_indent_style,
+            indent_size=self._json_indent_size,
+        )
+
     # ── Python-only API (used by IndexWorker) ────────────────────────────────
 
     @property
@@ -268,6 +335,15 @@ class SettingsModel(QObject):
                 apply_language(self._language)
             if isinstance(data.get("aiEnabled"), bool):
                 self._ai_enabled = data["aiEnabled"] and _AI_FEATURE_SUPPORTED
+            if isinstance(data.get("jsonExportPretty"), bool):
+                self._json_pretty = data["jsonExportPretty"]
+            if data.get("jsonExportIndentStyle") in _VALID_INDENT_STYLES:
+                self._json_indent_style = data["jsonExportIndentStyle"]
+            if isinstance(data.get("jsonExportIndentSize"), int):
+                self._json_indent_size = max(
+                    _MIN_JSON_INDENT_SIZE,
+                    min(_MAX_JSON_INDENT_SIZE, data["jsonExportIndentSize"]),
+                )
         except Exception:
             pass  # corrupt/missing file — use defaults
 
@@ -283,6 +359,9 @@ class SettingsModel(QObject):
                         "sortBy": self._sort_by,
                         "language": self._language,
                         "aiEnabled": self._ai_enabled,
+                        "jsonExportPretty": self._json_pretty,
+                        "jsonExportIndentStyle": self._json_indent_style,
+                        "jsonExportIndentSize": self._json_indent_size,
                     },
                     indent=2,
                 ),

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -4086,6 +4086,101 @@ ApplicationWindow {
 
                     Rectangle { Layout.fillWidth: true; height: 1; color: Material.dividerColor; Layout.bottomMargin: 28 }
 
+                    // ── JSON export formatting ────────────────────────────
+                    Label {
+                        text: qsTr("JSON Export Formatting")
+                        font.pixelSize: 14
+                        font.weight: Font.DemiBold
+                        Layout.bottomMargin: 6
+                    }
+                    Label {
+                        text: qsTr("Controls how the “Export Metadata as JSON” action writes its output. Compact keeps the current one-record-per-line layout; pretty-printed indents each record for readability.")
+                        font.pixelSize: 12
+                        opacity: 0.6
+                        wrapMode: Text.WordWrap
+                        Layout.fillWidth: true
+                        Layout.bottomMargin: 12
+                    }
+                    Switch {
+                        id: jsonPrettySwitch
+                        text: qsTr("Pretty-print (indented) JSON")
+                        checked: settingsModel ? settingsModel.jsonExportPretty : false
+                        onToggled: {
+                            if (settingsModel)
+                                settingsModel.setJsonExportPretty(checked)
+                        }
+                        Layout.bottomMargin: 12
+                    }
+                    RowLayout {
+                        spacing: 12
+                        enabled: jsonPrettySwitch.checked
+                        opacity: enabled ? 1.0 : 0.5
+                        Layout.bottomMargin: 12
+
+                        Label {
+                            text: qsTr("Indent style")
+                            font.pixelSize: 12
+                            opacity: 0.7
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        ComboBox {
+                            id: jsonIndentStyleCombo
+                            implicitWidth: 140
+                            readonly property var _opts: [
+                                { value: "space", label: qsTr("Spaces") },
+                                { value: "tab",   label: qsTr("Tabs") },
+                            ]
+                            model: _opts.map(function (o) { return o.label })
+                            currentIndex: {
+                                var v = settingsModel ? settingsModel.jsonExportIndentStyle : "space"
+                                for (var i = 0; i < _opts.length; ++i)
+                                    if (_opts[i].value === v) return i
+                                return 0
+                            }
+                            onActivated: {
+                                if (settingsModel)
+                                    settingsModel.setJsonExportIndentStyle(_opts[currentIndex].value)
+                            }
+                        }
+                    }
+                    RowLayout {
+                        spacing: 12
+                        enabled: jsonPrettySwitch.checked
+                                 && (settingsModel ? settingsModel.jsonExportIndentStyle === "space" : true)
+                        opacity: enabled ? 1.0 : 0.5
+                        Layout.bottomMargin: 28
+
+                        Label {
+                            text: qsTr("Indent size")
+                            font.pixelSize: 12
+                            opacity: 0.7
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                        ComboBox {
+                            id: jsonIndentSizeCombo
+                            implicitWidth: 100
+                            model: settingsModel ? settingsModel.jsonExportIndentSizeChoices : [2]
+                            currentIndex: {
+                                var v = settingsModel ? settingsModel.jsonExportIndentSize : 2
+                                var choices = settingsModel ? settingsModel.jsonExportIndentSizeChoices : [2]
+                                var idx = choices.indexOf(v)
+                                return idx >= 0 ? idx : 0
+                            }
+                            onActivated: {
+                                if (settingsModel)
+                                    settingsModel.setJsonExportIndentSize(model[currentIndex])
+                            }
+                        }
+                        Label {
+                            text: qsTr("spaces")
+                            font.pixelSize: 12
+                            opacity: 0.7
+                            verticalAlignment: Text.AlignVCenter
+                        }
+                    }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Material.dividerColor; Layout.bottomMargin: 28 }
+
                     // ── Indexing blacklist ────────────────────────────────
                     Label {
                         text: qsTr("Indexing Blacklist")

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -33,6 +33,7 @@ from ...utils.preview_cache import (
     preview_cache_name_from_stamp,
     preview_dir,
 )
+from ...utils.json_export import JsonExportFormat
 from ...utils.thumb_cache import thumb_cache_name_from_stamp
 from ..models.checked_filter_proxy_model import CheckedFilterProxyModel
 from ..models.exif_list_model import ExifListModel
@@ -799,6 +800,7 @@ class AppController(QObject):
             _("Exporting metadata\u2026"),
             file_path=file_path,
             sort_by=self._sort_by,
+            json_format=self._settings.json_export_format if self._settings else None,
         )
 
     @Slot()
@@ -816,6 +818,7 @@ class AppController(QObject):
         mark_value: bool = True,
         file_path: Path | None = None,
         sort_by: str = "path_asc",
+        json_format: JsonExportFormat | None = None,
         cache_dir: Path | None = None,
     ) -> None:
         """Spawn a BulkOpWorker and show the busy overlay."""
@@ -833,6 +836,7 @@ class AppController(QObject):
             mark_value=mark_value,
             file_path=file_path,
             sort_by=sort_by,
+            json_format=json_format,
             cache_dir=cache_dir,
             date_from=self._date_from,
             date_to=self._date_to,

--- a/src/exif_turbo/ui/workers/bulk_op_worker.py
+++ b/src/exif_turbo/ui/workers/bulk_op_worker.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 import os
 import threading
 from pathlib import Path
@@ -9,6 +8,7 @@ from typing import List
 from PySide6.QtCore import QThread, Signal
 
 from ...data.image_index_repository import ImageIndexRepository
+from ...utils.json_export import JsonExportFormat, render_record
 from ...utils.preview_cache import preview_cache_name_from_stamp, preview_dir
 from ...utils.thumb_cache import thumb_cache_name_from_stamp
 
@@ -44,6 +44,7 @@ class BulkOpWorker(QThread):
         # export_json
         file_path: Path | None = None,
         sort_by: str = "path_asc",
+        json_format: JsonExportFormat | None = None,
         # select_missing_thumbs
         cache_dir: Path | None = None,
         # date filter
@@ -62,6 +63,7 @@ class BulkOpWorker(QThread):
         self._mark_value = mark_value
         self._file_path = file_path
         self._sort_by = sort_by
+        self._json_format = json_format or JsonExportFormat()
         self._cache_dir = cache_dir
         self._date_from = date_from
         self._date_to = date_to
@@ -355,13 +357,14 @@ class BulkOpWorker(QThread):
 
         # Step 2: write JSON one record at a time so the progress bar advances
         assert self._file_path is not None
+        fmt = self._json_format
         with open(self._file_path, "w", encoding="utf-8") as fh:
             fh.write("[\n")
             for idx, record in enumerate(records):
                 if self._is_canceled():
                     self.canceled.emit()
                     return
-                fh.write(json.dumps(record, ensure_ascii=False))
+                fh.write(render_record(record, fmt))
                 if idx < total - 1:
                     fh.write(",\n")
                 else:

--- a/src/exif_turbo/utils/json_export.py
+++ b/src/exif_turbo/utils/json_export.py
@@ -1,0 +1,99 @@
+"""Formatting helpers for the *Export Marked Metadata as JSON* feature.
+
+The export is streamed one record at a time so the GUI progress bar can advance
+while a large database is written.  These helpers keep the formatting logic pure
+and testable, independent of the Qt worker that drives the streaming.
+
+The default format (``JsonExportFormat()``) reproduces the historical output
+byte-for-byte: a top-level array with each record serialised compactly on its
+own line.  Users can opt in to pretty-printed output and choose the indentation
+style (tabs or spaces) and, for spaces, the indentation width.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Iterable, Iterator
+
+INDENT_STYLE_SPACE = "space"
+INDENT_STYLE_TAB = "tab"
+_VALID_INDENT_STYLES = {INDENT_STYLE_SPACE, INDENT_STYLE_TAB}
+
+_MIN_INDENT_SIZE = 1
+_MAX_INDENT_SIZE = 8
+
+
+def normalize_indent_style(value: str) -> str:
+    """Return *value* if it is a supported indent style, else ``"space"``."""
+    return value if value in _VALID_INDENT_STYLES else INDENT_STYLE_SPACE
+
+
+def clamp_indent_size(value: int) -> int:
+    """Clamp *value* to the supported indentation width range."""
+    return max(_MIN_INDENT_SIZE, min(_MAX_INDENT_SIZE, value))
+
+
+@dataclass(frozen=True)
+class JsonExportFormat:
+    """Formatting options for a marked-metadata JSON export.
+
+    - ``pretty`` — when ``False`` (default) records are written compactly, one
+      per line, preserving the historical output.  When ``True`` each record is
+      indented for human readability.
+    - ``indent_style`` — ``"space"`` or ``"tab"``; only relevant when *pretty*.
+    - ``indent_size`` — number of spaces per indent level; only relevant when
+      *pretty* and *indent_style* is ``"space"``.
+    """
+
+    pretty: bool = False
+    indent_style: str = INDENT_STYLE_SPACE
+    indent_size: int = 2
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "indent_style", normalize_indent_style(self.indent_style))
+        object.__setattr__(self, "indent_size", clamp_indent_size(self.indent_size))
+
+    @property
+    def indent_unit(self) -> str | None:
+        """The string used for one indentation level, or ``None`` when compact."""
+        if not self.pretty:
+            return None
+        if self.indent_style == INDENT_STYLE_TAB:
+            return "\t"
+        return " " * self.indent_size
+
+
+def render_record(record: object, fmt: JsonExportFormat) -> str:
+    """Serialise a single *record* as it should appear inside the export array.
+
+    For pretty output the record is indented by one level so it nests neatly
+    beneath the enclosing ``[`` / ``]``.
+    """
+    indent = fmt.indent_unit
+    if indent is None:
+        return json.dumps(record, ensure_ascii=False)
+    body = json.dumps(record, ensure_ascii=False, indent=indent)
+    return "\n".join(indent + line for line in body.split("\n"))
+
+
+def iter_json_export(records: Iterable[object], fmt: JsonExportFormat) -> Iterator[str]:
+    """Yield the export text in chunks: opening bracket, each record, closing.
+
+    Yielding per record lets callers stream output and report progress.  The
+    record chunks already include the trailing comma/newline separators, so the
+    concatenation of every yielded chunk is the complete JSON document.
+    """
+    records = list(records)
+    total = len(records)
+    yield "[\n"
+    for idx, record in enumerate(records):
+        chunk = render_record(record, fmt)
+        chunk += ",\n" if idx < total - 1 else "\n"
+        yield chunk
+    yield "]\n"
+
+
+def dumps_json_export(records: Iterable[object], fmt: JsonExportFormat) -> str:
+    """Return the full export document as a single string."""
+    return "".join(iter_json_export(records, fmt))

--- a/tests/ui/test_bulk_op_worker_export.py
+++ b/tests/ui/test_bulk_op_worker_export.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytestqt.qtbot import QtBot
+
+from exif_turbo.data.image_index_repository import ImageIndexRepository
+from exif_turbo.ui.workers.bulk_op_worker import BulkOpWorker
+from exif_turbo.utils.json_export import JsonExportFormat
+
+
+@pytest.fixture
+def marked_db(tmp_path: Path) -> Path:
+    """A database file holding two marked images, ordered by path."""
+    db_path = tmp_path / "index.db"
+    repo = ImageIndexRepository(db_path, key="")
+    repo.upsert_image("/a.jpg", "a.jpg", 1.0, 10, {"Make": "Canon"}, "Canon")
+    repo.upsert_image("/b.jpg", "b.jpg", 2.0, 20, {"Make": "Nikon"}, "Nikon")
+    repo.mark_images(["/a.jpg", "/b.jpg"], True)
+    repo.close()
+    return db_path
+
+
+def _run_export(db_path: Path, out: Path, fmt: JsonExportFormat) -> None:
+    worker = BulkOpWorker(
+        db_path,
+        "",
+        "export_json",
+        file_path=out,
+        sort_by="path_asc",
+        json_format=fmt,
+    )
+    worker.run()
+
+
+def test_export_compact_writes_one_record_per_line(
+    qtbot: QtBot, marked_db: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    out = tmp_path / "compact.json"
+
+    # Act
+    _run_export(marked_db, out, JsonExportFormat())
+
+    # Assert
+    lines = out.read_text(encoding="utf-8").splitlines()
+    assert lines[0] == "[" and lines[-1] == "]"
+    assert '{"path": "/a.jpg"' in lines[1]
+
+
+def test_export_pretty_spaces_indents_records(
+    qtbot: QtBot, marked_db: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    out = tmp_path / "pretty.json"
+    fmt = JsonExportFormat(pretty=True, indent_style="space", indent_size=2)
+
+    # Act
+    _run_export(marked_db, out, fmt)
+
+    # Assert
+    text = out.read_text(encoding="utf-8")
+    assert '\n    "path": "/a.jpg"' in text  # 2 (array level) + 2 (object level)
+    assert [r["path"] for r in json.loads(text)] == ["/a.jpg", "/b.jpg"]
+
+
+def test_export_pretty_tabs_uses_tab_indentation(
+    qtbot: QtBot, marked_db: Path, tmp_path: Path
+) -> None:
+    # Arrange
+    out = tmp_path / "tabs.json"
+    fmt = JsonExportFormat(pretty=True, indent_style="tab")
+
+    # Act
+    _run_export(marked_db, out, fmt)
+
+    # Assert
+    text = out.read_text(encoding="utf-8")
+    assert '\n\t\t"path": "/a.jpg"' in text

--- a/tests/ui/test_settings_model_json_export.py
+++ b/tests/ui/test_settings_model_json_export.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pytestqt.qtbot import QtBot
+
+from exif_turbo.ui.models.settings_model import SettingsModel
+
+
+@pytest.fixture
+def settings_file(tmp_path: Path) -> Path:
+    """Path to a fresh per-database settings.json inside a temp dir."""
+    return tmp_path / "settings.json"
+
+
+def test_json_export_defaults_are_compact(qtbot: QtBot, settings_file: Path) -> None:
+    # Arrange / Act
+    model = SettingsModel(settings_file)
+
+    # Assert
+    fmt = model.json_export_format
+    assert (fmt.pretty, fmt.indent_style, fmt.indent_size) == (False, "space", 2)
+
+
+def test_set_json_export_pretty_persists_across_reload(qtbot: QtBot, settings_file: Path) -> None:
+    # Arrange
+    model = SettingsModel(settings_file)
+
+    # Act
+    model.setJsonExportPretty(True)
+    reloaded = SettingsModel(settings_file)
+
+    # Assert
+    assert reloaded.jsonExportPretty is True
+
+
+def test_set_json_indent_style_tab_persists(qtbot: QtBot, settings_file: Path) -> None:
+    # Arrange
+    model = SettingsModel(settings_file)
+
+    # Act
+    model.setJsonExportIndentStyle("tab")
+    reloaded = SettingsModel(settings_file)
+
+    # Assert
+    assert reloaded.jsonExportIndentStyle == "tab"
+
+
+def test_set_json_indent_style_rejects_unknown_value(qtbot: QtBot, settings_file: Path) -> None:
+    # Arrange
+    model = SettingsModel(settings_file)
+
+    # Act
+    model.setJsonExportIndentStyle("curly")
+
+    # Assert
+    assert model.jsonExportIndentStyle == "space"
+
+
+def test_set_json_indent_size_clamps_to_supported_range(qtbot: QtBot, settings_file: Path) -> None:
+    # Arrange
+    model = SettingsModel(settings_file)
+
+    # Act
+    model.setJsonExportIndentSize(999)
+
+    # Assert
+    assert model.jsonExportIndentSize == 8
+
+
+def test_corrupt_indent_size_falls_back_to_clamped_value(qtbot: QtBot, settings_file: Path) -> None:
+    # Arrange
+    settings_file.write_text(json.dumps({"jsonExportIndentSize": 0}), encoding="utf-8")
+
+    # Act
+    model = SettingsModel(settings_file)
+
+    # Assert
+    assert model.jsonExportIndentSize == 1

--- a/tests/utils/test_json_export.py
+++ b/tests/utils/test_json_export.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+
+from exif_turbo.utils.json_export import (
+    JsonExportFormat,
+    clamp_indent_size,
+    dumps_json_export,
+    normalize_indent_style,
+    render_record,
+)
+
+
+_RECORDS = [
+    {"path": "/a.jpg", "filename": "a.jpg", "metadata": {"Make": "Canon"}},
+    {"path": "/b.jpg", "filename": "b.jpg", "metadata": {"Make": "Nikon"}},
+]
+
+
+def test_dumps_json_export_default_is_compact_one_record_per_line() -> None:
+    # Arrange
+    fmt = JsonExportFormat()
+
+    # Act
+    text = dumps_json_export(_RECORDS, fmt)
+
+    # Assert
+    expected = (
+        "[\n"
+        + json.dumps(_RECORDS[0], ensure_ascii=False)
+        + ",\n"
+        + json.dumps(_RECORDS[1], ensure_ascii=False)
+        + "\n]\n"
+    )
+    assert text == expected
+
+
+def test_dumps_json_export_default_roundtrips_to_original_records() -> None:
+    # Arrange
+    fmt = JsonExportFormat()
+
+    # Act
+    parsed = json.loads(dumps_json_export(_RECORDS, fmt))
+
+    # Assert
+    assert parsed == _RECORDS
+
+
+def test_dumps_json_export_pretty_spaces_indents_with_given_width() -> None:
+    # Arrange
+    fmt = JsonExportFormat(pretty=True, indent_style="space", indent_size=4)
+
+    # Act
+    text = dumps_json_export(_RECORDS[:1], fmt)
+
+    # Assert
+    assert '\n        "path": "/a.jpg"' in text  # 4 (array level) + 4 (object level)
+    assert json.loads(text) == _RECORDS[:1]
+
+
+def test_dumps_json_export_pretty_tabs_indents_with_tab_characters() -> None:
+    # Arrange
+    fmt = JsonExportFormat(pretty=True, indent_style="tab")
+
+    # Act
+    text = dumps_json_export(_RECORDS[:1], fmt)
+
+    # Assert
+    assert '\n\t\t"path": "/a.jpg"' in text
+    assert json.loads(text) == _RECORDS[:1]
+
+
+def test_dumps_json_export_pretty_ignores_indent_size_for_tabs() -> None:
+    # Arrange
+    fmt = JsonExportFormat(pretty=True, indent_style="tab", indent_size=4)
+
+    # Act
+    text = dumps_json_export(_RECORDS[:1], fmt)
+
+    # Assert
+    assert "    " not in text  # no space-based indentation present
+
+
+def test_render_record_compact_has_no_newlines() -> None:
+    # Arrange
+    fmt = JsonExportFormat()
+
+    # Act
+    rendered = render_record(_RECORDS[0], fmt)
+
+    # Assert
+    assert "\n" not in rendered
+
+
+def test_json_export_format_normalizes_unknown_indent_style_to_space() -> None:
+    # Arrange / Act
+    fmt = JsonExportFormat(pretty=True, indent_style="weird")
+
+    # Assert
+    assert fmt.indent_style == "space"
+
+
+def test_json_export_format_clamps_indent_size_to_supported_range() -> None:
+    # Arrange / Act
+    fmt = JsonExportFormat(pretty=True, indent_size=999)
+
+    # Assert
+    assert fmt.indent_size == 8
+
+
+def test_normalize_indent_style_passes_through_valid_value() -> None:
+    # Arrange / Act / Assert
+    assert normalize_indent_style("tab") == "tab"
+
+
+def test_clamp_indent_size_floors_below_minimum() -> None:
+    # Arrange / Act / Assert
+    assert clamp_indent_size(0) == 1


### PR DESCRIPTION
## Summary

Implements #19 — adds user-configurable formatting for the **Export Marked Metadata as JSON** feature. Exports can now be pretty-printed for readability or kept compact for size.

## Changes

- **New `utils/json_export.py`** — a pure, testable helper defining a self-validating `JsonExportFormat` (pretty toggle, indent style, indent size) plus the render functions used by the export worker.
- **`SettingsModel`** — new `jsonExportPretty` / `jsonExportIndentStyle` / `jsonExportIndentSize` properties, persisted across sessions, with validation/clamping.
- **`AppController` → `BulkOpWorker`** — the chosen format is threaded through the export path.
- **Settings UI (`Main.qml`)** — new "JSON Export Formatting" section: a pretty switch, an indent-style selector (spaces/tabs), and an indent-size selector enabled only when pretty + spaces are active.
- **Docs** — README and user manual updated.

## Backward compatibility

The default is **compact**, producing **byte-identical** output to the previous behaviour. Existing exports are unchanged unless the user opts in.

## Testing

19 new tests, all passing:
- `tests/utils/test_json_export.py` — compact/pretty, tabs/spaces, width, validation
- `tests/ui/test_settings_model_json_export.py` — defaults, persistence, validation, clamping
- `tests/ui/test_bulk_op_worker_export.py` — end-to-end file writing

Closes #19