### PR TITLE
chore: make Dependabot update pip version constraints

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    versioning-strategy: "increase"
     groups:
       security-patches:
         update-types:


### PR DESCRIPTION
Summary: Update Dependabot to increase pip requirement constraints when newer versions are available.

What changed:
- Added versioning-strategy: increase in .github/dependabot.yml

Why:
- Dependencies in pyproject.toml mostly use lower-bound constraints.
- This helps Dependabot open version-update PRs more reliably.

Expected impact:
- More regular pip dependency update PRs.
- Security behavior unchanged.