### PR TITLE
fix: remove versioning-strategy from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    versioning-strategy: "increase"
     groups:
       security-patches:
         update-types:


### PR DESCRIPTION
Removes the `versioning-strategy: "increase"` line from `.github/dependabot.yml` as it is not needed and can cause issues with dependabot updates.