### PR TITLE
Fix AI-mode year filter collapsing timeline to single year

### DIFF
--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -253,6 +253,10 @@ class AppController(QObject):
         self._ai_select_first: bool = False
         # All AI result rows held in memory so we can page them without SQL.
         self._ai_result_cache: list[SearchResult] = []
+        # Semantic result paths BEFORE the date filter is applied.  Drives the
+        # AI-mode year histogram so selecting a single year does not collapse
+        # the other selectable years.
+        self._ai_facet_paths: list[str] = []
         self._ai_scan_folder_id: int = 0
         self._ai_scan_is_full_rescan: bool = False
         self._ai_scan_current: int = 0
@@ -1371,6 +1375,7 @@ class AppController(QObject):
             "was_ai_search_mode": self._is_ai_search_mode,
             "current_image_id": self._search_model.get_image_id(self._current_result_row) or 0,
             "ai_rows": list(self._ai_result_cache) if self._is_ai_search_mode else None,
+            "ai_facet_paths": list(self._ai_facet_paths) if self._is_ai_search_mode else None,
             "ai_total_results": self._total_results if self._is_ai_search_mode else 0,
             "ai_loaded_results": self._loaded_results if self._is_ai_search_mode else 0,
         }
@@ -1443,6 +1448,10 @@ class AppController(QObject):
             # Restore AI results directly — no re-search, no model reload.
             saved_rows = snapshot["ai_rows"]
             self._ai_result_cache = saved_rows
+            self._ai_facet_paths = (
+                snapshot.get("ai_facet_paths")
+                or [res.path for res in saved_rows]
+            )
             self._loaded_offset = 0
             self._loading = True
             target_source_row = -1
@@ -1587,7 +1596,11 @@ class AppController(QObject):
         format_counts: list,
         serial: int,
     ) -> None:
+        ai_facet_paths: list[str] | None = None
         if self.sender() is self._ai_search_worker:
+            ai_facet_paths = list(
+                getattr(self._ai_search_worker, "facet_paths", []) or []
+            )
             self._ai_search_worker = None
         old_worker = self._search_worker
         self._search_worker = None
@@ -1637,6 +1650,14 @@ class AppController(QObject):
         # by loadMore() without touching the database.
         if self._is_ai_search_mode:
             self._ai_result_cache = all_results
+            # Timeline facet source: the semantic set before date filtering.
+            # Fall back to the (date-filtered) result paths if the worker did
+            # not supply a facet list (e.g. a non-AI worker path).
+            self._ai_facet_paths = (
+                ai_facet_paths
+                if ai_facet_paths is not None
+                else [res.path for res in all_results]
+            )
             first_page = all_results[:_PAGE_SIZE]
             self._loaded_offset = 0
         else:
@@ -1836,12 +1857,14 @@ class AppController(QObject):
         """Return source paths used for AI mode facet/timeline counts.
 
         Empty AI text query keeps facets broad (folder-scope only), while a
-        non-empty query follows the semantic result set.
+        non-empty query follows the semantic result set.  In both cases the
+        active date filter is intentionally ignored so picking one year does
+        not hide the other years from the histogram.
         """
         if self._repo is None:
             return []
         if self._last_ai_query.strip():
-            return [res.path for res in self._ai_result_cache]
+            return list(self._ai_facet_paths)
         return sorted(
             self._repo.get_filtered_paths(
                 path_filter=self._current_path_filter(),

--- a/src/exif_turbo/ui/workers/ai_search_worker.py
+++ b/src/exif_turbo/ui/workers/ai_search_worker.py
@@ -65,6 +65,10 @@ class AiSearchWorker(QThread):
         self._ext_filter = ext_filter
         self._date_from = date_from
         self._date_to = date_to
+        # Semantic result paths BEFORE the date filter is applied.  The
+        # controller reads this to build the year-histogram so selecting a
+        # single year does not collapse the other selectable years.
+        self.facet_paths: List[str] = []
         # macOS limits secondary thread stacks to 512 kB by default, which is
         # too small for the lazy torch + open_clip imports.  64 MB gives ample
         # headroom without measurable overhead.
@@ -80,14 +84,16 @@ class AiSearchWorker(QThread):
 
             image_repo = ImageIndexRepository(self._db_path, key=self._key)
             try:
-                allowed_paths = image_repo.get_filtered_paths(
+                # Facet scope: path/ext/folder filters WITHOUT the date filter.
+                # Drives the timeline so picking a single year does not collapse
+                # the other selectable years.
+                facet_allowed_paths = image_repo.get_filtered_paths(
                     path_filter=self._path_filter,
                     ext_filter=self._ext_filter,
                     restrict_to_enabled_folders=True,
-                    date_from=self._date_from,
-                    date_to=self._date_to,
                 )
-                if not allowed_paths:
+                if not facet_allowed_paths:
+                    self.facet_paths = []
                     self.results_ready.emit([], 0, [], self._serial)
                     return
 
@@ -98,14 +104,34 @@ class AiSearchWorker(QThread):
 
                     hits = vector_repo.search_filtered(
                         query_vec,
-                        allowed_paths,
+                        facet_allowed_paths,
                         top_k=self._MAX_RESULTS,
                         threshold=self._threshold,
                     )
-                    ranked_paths = [path for path, _score in hits]
+                    ranked_facet_paths = [path for path, _score in hits]
                 else:
                     # Empty AI query means "show everything in scope".
-                    ranked_paths = sorted(allowed_paths)
+                    ranked_facet_paths = sorted(facet_allowed_paths)
+
+                # The timeline facet source is the full semantic set, before the
+                # date filter narrows the displayed rows.
+                self.facet_paths = list(ranked_facet_paths)
+
+                # Displayed rows additionally honour the active date filter.
+                if self._date_from is not None or self._date_to is not None:
+                    date_allowed_paths = image_repo.get_filtered_paths(
+                        path_filter=self._path_filter,
+                        ext_filter=self._ext_filter,
+                        restrict_to_enabled_folders=True,
+                        date_from=self._date_from,
+                        date_to=self._date_to,
+                    )
+                    ranked_paths = [
+                        path for path in ranked_facet_paths
+                        if path in date_allowed_paths
+                    ]
+                else:
+                    ranked_paths = ranked_facet_paths
 
                 rows = image_repo.get_images_by_paths(
                     ranked_paths,

--- a/tests/ui/test_ai_search_worker.py
+++ b/tests/ui/test_ai_search_worker.py
@@ -327,6 +327,67 @@ def test_ai_search_worker_applies_ext_and_date_filters_to_hits(
     assert [row[1] for row in rows] == [str(jpg_path)]
 
 
+def test_ai_search_worker_date_filter_keeps_facet_paths_for_all_years(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    # Arrange — two semantic hits in different years; date filter covers 2024 only
+    db_path = tmp_path / "test.db"
+    gallery_dir = tmp_path / "gallery"
+    gallery_dir.mkdir()
+
+    path_2024 = make_jpeg(gallery_dir / "photo_2024.jpg")
+    path_2025 = make_jpeg(gallery_dir / "photo_2025.jpg")
+
+    folder_id = _seed_folder(db_path, gallery_dir, enabled=True)
+    _seed_image(
+        db_path, path_2024, folder_id, "Canon", captured_at=1704067200.0
+    )  # 2024-01-01T00:00:00Z
+    _seed_image(
+        db_path, path_2025, folder_id, "Canon", captured_at=1735689600.0
+    )  # 2025-01-01T00:00:00Z
+
+    _FakeAiVectorRepository.hits = [
+        (str(path_2025), 0.96),
+        (str(path_2024), 0.95),
+    ]
+    monkeypatch.setattr(
+        "exif_turbo.ui.workers.ai_search_worker.AiVectorRepository",
+        _FakeAiVectorRepository,
+    )
+    monkeypatch.setattr(
+        "exif_turbo.ui.workers.ai_search_worker.AiIndexerService",
+        _FakeAiIndexerService,
+    )
+
+    emitted: list[tuple[list[tuple[int, str, str, str, int, float]], int, list, int]] = []
+    failures: list[str] = []
+    worker = AiSearchWorker(
+        db_path,
+        "",
+        "landscape",
+        23,
+        date_from=1704067200,
+        date_to=1735603199,  # just before 2025-01-01T00:00:00Z
+    )
+    worker.results_ready.connect(
+        lambda rows, total, format_counts, serial: emitted.append(
+            (rows, total, format_counts, serial)
+        )
+    )
+    worker.failed.connect(failures.append)
+
+    # Act
+    worker.run()
+
+    # Assert — displayed rows honour the date filter, but the timeline facet
+    # source keeps every semantic year so the histogram does not collapse.
+    assert failures == []
+    rows = emitted[0][0]
+    assert [row[1] for row in rows] == [str(path_2024)]
+    assert set(worker.facet_paths) == {str(path_2024), str(path_2025)}
+
+
 def test_ai_search_worker_calls_vector_search_with_2000_result_cap(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Problem

In the Search tab in AI-Mode, clicking a time-range year immediately selected that single year and all other years disappeared from the histogram, making it impossible to select a range of years.

## Root cause

The AI search worker applied the active date filter to its candidate path set, and the year histogram was then rebuilt from that already date-filtered AI result set. After the first click, only the selected year remained visible — so a second (Shift-)click to extend the range was impossible.

## Fix

- The AI search worker now computes the semantic result set against the path/ext/folder scope only (no date filter) and exposes it as acet_paths. The date filter is applied afterward to narrow only the displayed rows.
- The controller stores this non-date-filtered facet set (_ai_facet_paths) and drives the year histogram from it, so selecting one year keeps the other years selectable for range extension.
- The facet set is preserved across the Browse snapshot/restore round-trip.

EXIF mode behavior is unchanged.

## Tests

- Added \	est_ai_search_worker_date_filter_keeps_facet_paths_for_all_years\ verifying displayed rows honour the date filter while \acet_paths\ retains every semantic year.
- Existing AI worker, AI folder-filter visibility, and image index repository suites pass.