### PR TITLE
Warn in status bar when an indexed file's data source is not attached

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -433,6 +433,12 @@ default application:
   folder in the system file manager. On Windows, Explorer opens with the file
   highlighted; on macOS and Linux the parent folder is opened.
 
+If the original file cannot be reached — for example when the folder that
+contains it is not currently mounted or attached — nothing is opened and a
+**red warning** appears in the status bar at the bottom of the window naming
+the indexed folder you need to (re)attach or mount, e.g. *"Original data
+source not attached: D:\Photos — attach or mount this folder to open files."*
+
 ### Search examples
 
 | Query | What it finds |

--- a/scripts/populate_translations.py
+++ b/scripts/populate_translations.py
@@ -157,6 +157,8 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "Folder(s)": "Ordner",
         "Reset Database": "Datenbank zur\u00fccksetzen",
         "Database reset": "Datenbank zur\u00fcckgesetzt",
+        "Original data source not attached: {source} \u2014 attach or mount this folder to open files.":
+            "Originale Datenquelle nicht angeh\u00e4ngt: {source} \u2014 H\u00e4ngen Sie diesen Ordner an oder binden Sie ihn ein, um Dateien zu \u00f6ffnen.",
         "ExifTool not found": "ExifTool nicht gefunden",
         "ExifTool was not found on your system. Indexing is disabled until ExifTool is installed and available on your PATH.": "ExifTool wurde auf Ihrem System nicht gefunden. Die Indizierung ist deaktiviert, bis ExifTool installiert und auf Ihrem PATH verf\u00fcgbar ist.",
         "Download ExifTool from:": "ExifTool herunterladen unter:",
@@ -446,6 +448,8 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "Folder(s)": "Dossier(s)",
         "Reset Database": "R\u00e9initialiser la base de donn\u00e9es",
         "Database reset": "Base de donn\u00e9es r\u00e9initialis\u00e9e",
+        "Original data source not attached: {source} \u2014 attach or mount this folder to open files.":
+            "Source de donn\u00e9es d'origine non rattach\u00e9e\u00a0: {source} \u2014 rattachez ou montez ce dossier pour ouvrir les fichiers.",
         "ExifTool not found": "ExifTool introuvable",
         "ExifTool was not found on your system. Indexing is disabled until ExifTool is installed and available on your PATH.": "ExifTool n\u2019a pas \u00e9t\u00e9 trouv\u00e9 sur votre syst\u00e8me. L\u2019indexation est d\u00e9sactiv\u00e9e jusqu\u2019\u00e0 ce qu\u2019ExifTool soit install\u00e9 et disponible dans votre PATH.",
         "Download ExifTool from:": "T\u00e9l\u00e9charger ExifTool sur\u00a0:",
@@ -743,6 +747,8 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "Folder(s)": "Cartella/e",
         "Reset Database": "Ripristina database",
         "Database reset": "Database ripristinato",
+        "Original data source not attached: {source} \u2014 attach or mount this folder to open files.":
+            "Origine dati originale non collegata: {source} \u2014 collega o monta questa cartella per aprire i file.",
         "ExifTool not found": "ExifTool non trovato",
         "ExifTool was not found on your system. Indexing is disabled until ExifTool is installed and available on your PATH.": "ExifTool non \u00e8 stato trovato sul tuo sistema. L\u2019indicizzazione \u00e8 disabilitata finch\u00e9 ExifTool non viene installato e reso disponibile nel tuo PATH.",
         "Download ExifTool from:": "Scarica ExifTool da:",
@@ -1037,6 +1043,8 @@ TRANSLATIONS: dict[str, dict[str, str]] = {
         "Folder(s)": "Cartella(s)",
         "Reset Database": "Resettar banca da datas",
         "Database reset": "Banca da datas resettada",
+        "Original data source not attached: {source} \u2014 attach or mount this folder to open files.":
+            "Funtauna da datas originala betg colliada: {source} \u2014 colliai u montai questa cartella per avrir datotecas.",
         "ExifTool not found": "ExifTool betg chattà",
         "ExifTool was not found on your system. Indexing is disabled until ExifTool is installed and available on your PATH.": "ExifTool n\u2019\u00e8 betg vegnì chattà sin voss sistem. L\u2019indexaziun \u00e8 deactivada fin che ExifTool \u00e8 installà ed disponibel sin voss PATH.",
         "Download ExifTool from:": "Telechargiar ExifTool da:",

--- a/src/exif_turbo/i18n/locales/de/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/de/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-28 19:41+0200\n"
+"POT-Creation-Date: 2026-06-29 20:42+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -26,121 +26,121 @@ msgstr "PyTorch ist auf macOS Intel für Python 3.13+ nicht verfügbar."
 msgid "Enter the database password to continue"
 msgstr "Datenbankpasswort eingeben, um fortzufahren"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:747
+#: src/exif_turbo/ui/view_models/app_controller.py:752
 msgid "Selecting all matching images…"
 msgstr "Alle passenden Bilder werden ausgewählt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:757
+#: src/exif_turbo/ui/view_models/app_controller.py:762
 msgid "Deselecting all matching images…"
 msgstr "Auswahl aller passenden Bilder wird aufgehoben…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:767
+#: src/exif_turbo/ui/view_models/app_controller.py:772
 msgid "Inverting selection…"
 msgstr "Auswahl wird umgekehrt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:781
+#: src/exif_turbo/ui/view_models/app_controller.py:786
 msgid "Selecting images without a cached thumbnail…"
 msgstr "Bilder ohne gecachte Miniaturansicht werden ausgewählt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:796
+#: src/exif_turbo/ui/view_models/app_controller.py:801
 msgid "No marked images to delete."
 msgstr "Keine markierten Bilder zum Löschen."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:800
+#: src/exif_turbo/ui/view_models/app_controller.py:805
 msgid "Deleting marked images…"
 msgstr "Markierte Bilder werden gelöscht…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:810
+#: src/exif_turbo/ui/view_models/app_controller.py:815
 msgid "No marked images to export."
 msgstr "Keine markierten Bilder zum Exportieren."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:815
+#: src/exif_turbo/ui/view_models/app_controller.py:820
 msgid "Exporting metadata…"
 msgstr "Metadaten werden exportiert…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:917
+#: src/exif_turbo/ui/view_models/app_controller.py:922
 #, python-brace-format
 msgid "Deleted {n} image(s)."
 msgstr "{n} Bild(er) gelöscht."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:921
+#: src/exif_turbo/ui/view_models/app_controller.py:926
 #, python-brace-format
 msgid "{n} were already missing."
 msgstr "{n} waren bereits nicht mehr vorhanden."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:927
+#: src/exif_turbo/ui/view_models/app_controller.py:932
 #, python-brace-format
 msgid "{n} could not be deleted."
 msgstr "{n} konnten nicht gelöscht werden."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:937
+#: src/exif_turbo/ui/view_models/app_controller.py:942
 #, python-brace-format
 msgid "Exported {count} image(s) to {name}"
 msgstr "{count} Bild(er) nach {name} exportiert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:946
-#: src/exif_turbo/ui/view_models/app_controller.py:1028
+#: src/exif_turbo/ui/view_models/app_controller.py:951
+#: src/exif_turbo/ui/view_models/app_controller.py:1033
 #, python-brace-format
 msgid "Operation failed: {}"
 msgstr "Vorgang fehlgeschlagen: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:952
-#: src/exif_turbo/ui/view_models/app_controller.py:1034
+#: src/exif_turbo/ui/view_models/app_controller.py:957
+#: src/exif_turbo/ui/view_models/app_controller.py:1039
 msgid "Operation canceled."
 msgstr "Vorgang abgebrochen."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1119
+#: src/exif_turbo/ui/view_models/app_controller.py:1125
 msgid "Wrong password — please try again."
 msgstr "Falsches Passwort — bitte erneut versuchen."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1131
+#: src/exif_turbo/ui/view_models/app_controller.py:1137
 #, python-brace-format
 msgid "Failed to open database: {error}"
 msgstr "Datenbank konnte nicht geöffnet werden: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1157
+#: src/exif_turbo/ui/view_models/app_controller.py:1163
 msgid "Database is locked."
 msgstr "Die Datenbank ist gesperrt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1162
+#: src/exif_turbo/ui/view_models/app_controller.py:1168
 msgid "Cannot change password while indexing or thumb-building is running."
 msgstr ""
 "Das Passwort kann nicht geändert werden, während Indizierung oder "
 "Miniaturansichterstellung läuft."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1166
+#: src/exif_turbo/ui/view_models/app_controller.py:1172
 msgid "Current password is incorrect."
 msgstr "Das aktuelle Passwort ist falsch."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1169
+#: src/exif_turbo/ui/view_models/app_controller.py:1175
 msgid "New password must not be empty."
 msgstr "Das neue Passwort darf nicht leer sein."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1173
+#: src/exif_turbo/ui/view_models/app_controller.py:1179
 msgid "New password must differ from the current password."
 msgstr "Das neue Passwort muss sich vom aktuellen unterscheiden."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1191
+#: src/exif_turbo/ui/view_models/app_controller.py:1197
 msgid "Changing password…"
 msgstr "Passwort wird geändert…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1232
+#: src/exif_turbo/ui/view_models/app_controller.py:1238
 #, python-brace-format
 msgid "Database password changed, but reopening failed: {error}"
 msgstr ""
 "Datenbankpasswort geändert, aber das erneute Öffnen ist fehlgeschlagen: "
 "{error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1242
+#: src/exif_turbo/ui/view_models/app_controller.py:1248
 msgid "Password changed successfully."
 msgstr "Passwort erfolgreich geändert."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1283
+#: src/exif_turbo/ui/view_models/app_controller.py:1289
 #, python-brace-format
 msgid "Failed to change password: {error}"
 msgstr "Passwortänderung fehlgeschlagen: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1288
+#: src/exif_turbo/ui/view_models/app_controller.py:1294
 #, python-brace-format
 msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
@@ -150,181 +150,189 @@ msgstr ""
 "neu verschlüsselt werden ({error}). Der Cache wurde geleert und wird neu "
 "erstellt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2080
+#: src/exif_turbo/ui/view_models/app_controller.py:2086
 msgid "Folder list reloaded."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2313
+#: src/exif_turbo/ui/view_models/app_controller.py:2319
 #, python-brace-format
 msgid "Folder already tracked: {}"
 msgstr "Ordner bereits verfolgt: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2340
+#: src/exif_turbo/ui/view_models/app_controller.py:2346
 msgid "Removing folder…"
 msgstr "Ordner wird entfernt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2512
+#: src/exif_turbo/ui/view_models/app_controller.py:2518
 msgid "Folder not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2518
+#: src/exif_turbo/ui/view_models/app_controller.py:2524
 #, python-brace-format
 msgid "Folder not accessible: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2557
+#: src/exif_turbo/ui/view_models/app_controller.py:2563
 #, python-brace-format
 msgid "Indexing {}…"
 msgstr "Indizierung von {}…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2593
+#: src/exif_turbo/ui/view_models/app_controller.py:2599
 #, python-brace-format
 msgid "Indexed {count} images ({errors} skipped due to errors)"
 msgstr "{count} Bilder indiziert ({errors} aufgrund von Fehlern übersprungen)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2598
+#: src/exif_turbo/ui/view_models/app_controller.py:2604
 #, python-brace-format
 msgid "Indexed {} images"
 msgstr "{} Bilder indiziert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2631
+#: src/exif_turbo/ui/view_models/app_controller.py:2637
 #, python-brace-format
 msgid "Index failed: {}"
 msgstr "Indizierung fehlgeschlagen: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2663
+#: src/exif_turbo/ui/view_models/app_controller.py:2669
 msgid "Index canceled"
 msgstr "Indizierung abgebrochen"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2683
+#: src/exif_turbo/ui/view_models/app_controller.py:2689
 msgid "Canceling…"
 msgstr "Abbrechen…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2876
+#: src/exif_turbo/ui/view_models/app_controller.py:2882
 #, python-brace-format
 msgid "AI full rescan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2878
+#: src/exif_turbo/ui/view_models/app_controller.py:2884
 #, python-brace-format
 msgid "AI-Scan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2880
+#: src/exif_turbo/ui/view_models/app_controller.py:2886
 #, python-brace-format
 msgid "{n} file(s) could not be processed."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2887
+#: src/exif_turbo/ui/view_models/app_controller.py:2893
 #, python-brace-format
 msgid "AI full rescan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2889
+#: src/exif_turbo/ui/view_models/app_controller.py:2895
 #, python-brace-format
 msgid "AI-Scan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2896
+#: src/exif_turbo/ui/view_models/app_controller.py:2902
 #, python-brace-format
 msgid "AI full rescan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2900
+#: src/exif_turbo/ui/view_models/app_controller.py:2906
 #, python-brace-format
 msgid "AI-Scan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2926
+#: src/exif_turbo/ui/view_models/app_controller.py:2932
 #, python-brace-format
 msgid "Built {built} preview(s) of {total}."
 msgstr "{built} von {total} Vorschaubilder erstellt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2930
+#: src/exif_turbo/ui/view_models/app_controller.py:2936
 #, python-brace-format
 msgid "{n} image(s) skipped — too large to decode safely."
 msgstr "{n} Bild(er) übersprungen — zu groß zum sicheren Dekodieren."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2940
+#: src/exif_turbo/ui/view_models/app_controller.py:2946
 #, python-brace-format
 msgid "Preview build failed: {error}"
 msgstr "Vorschaubilderstellung fehlgeschlagen: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2948
+#: src/exif_turbo/ui/view_models/app_controller.py:2954
 #, python-brace-format
 msgid "Preview build canceled ({built} of {total} done)."
 msgstr "Vorschaubilderstellung abgebrochen ({built} von {total} fertig)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2961
+#: src/exif_turbo/ui/view_models/app_controller.py:2967
 msgid "Cancel the running preview build before clearing the cache."
 msgstr ""
 "Bitte die laufende Vorschaubilderstellung abbrechen, bevor der Cache "
 "geleert wird."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2970
+#: src/exif_turbo/ui/view_models/app_controller.py:2976
 #, python-brace-format
 msgid "Failed to clear preview cache: {error}"
 msgstr "Löschen des Vorschau-Caches fehlgeschlagen: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2976
+#: src/exif_turbo/ui/view_models/app_controller.py:2982
 #, python-brace-format
 msgid "Removed {n} cached preview(s)."
 msgstr "{n} gecachtes Vorschaubild(er) entfernt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3085
+#: src/exif_turbo/ui/view_models/app_controller.py:3091
 msgid "File not accessible — path copied"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3109
+#: src/exif_turbo/ui/view_models/app_controller.py:3115
 msgid "Image copied to clipboard"
 msgstr "Bild in Zwischenablage kopiert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3113
+#: src/exif_turbo/ui/view_models/app_controller.py:3119
 msgid "Path copied to clipboard"
 msgstr "Pfad in Zwischenablage kopiert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3122
-#: src/exif_turbo/ui/view_models/app_controller.py:3142
+#: src/exif_turbo/ui/view_models/app_controller.py:3128
+#: src/exif_turbo/ui/view_models/app_controller.py:3148
 msgid "File not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3131
+#: src/exif_turbo/ui/view_models/app_controller.py:3137
 msgid "Preview saved"
 msgstr "Vorschau gespeichert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3147
+#: src/exif_turbo/ui/view_models/app_controller.py:3153
 msgid "Original saved"
 msgstr "Original gespeichert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3200
+#: src/exif_turbo/ui/view_models/app_controller.py:3206
 msgid "Resetting database…"
 msgstr "Datenbank wird zurückgesetzt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3223
+#: src/exif_turbo/ui/view_models/app_controller.py:3229
 msgid "Database reset"
 msgstr "Datenbank zurückgesetzt"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3240
-#: src/exif_turbo/ui/view_models/app_controller.py:3252
+#: src/exif_turbo/ui/view_models/app_controller.py:3323
+#, python-brace-format
+msgid ""
+"Original data source not attached: {source} — attach or mount this folder"
+" to open files."
+msgstr ""
+"Originale Datenquelle nicht angehängt: {source} — Hängen Sie diesen "
+"Ordner an oder binden Sie ihn ein, um Dateien zu öffnen."
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3330
 #, python-brace-format
 msgid "File not found: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3418
+#: src/exif_turbo/ui/view_models/app_controller.py:3476
 msgid "Cleaning up cache…"
 msgstr "Cache wird bereinigt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3438
+#: src/exif_turbo/ui/view_models/app_controller.py:3496
 #, python-brace-format
 msgid "Indexing… {} (scanning)"
 msgstr "Indizierung… {} (Suche)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3440
+#: src/exif_turbo/ui/view_models/app_controller.py:3498
 #, python-brace-format
 msgid "Indexing… 0 / {}"
 msgstr "Indizierung… 0 / {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3442
+#: src/exif_turbo/ui/view_models/app_controller.py:3500
 #, python-brace-format
 msgid "Indexing… {} / {}"
 msgstr "Indizierung… {} / {}"

--- a/src/exif_turbo/i18n/locales/fr/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/fr/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-28 19:41+0200\n"
+"POT-Creation-Date: 2026-06-29 20:42+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -26,121 +26,121 @@ msgstr "PyTorch n’est pas disponible sur macOS Intel pour Python 3.13+."
 msgid "Enter the database password to continue"
 msgstr "Saisir le mot de passe de la base de données pour continuer"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:747
+#: src/exif_turbo/ui/view_models/app_controller.py:752
 msgid "Selecting all matching images…"
 msgstr "Sélection de toutes les images correspondantes…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:757
+#: src/exif_turbo/ui/view_models/app_controller.py:762
 msgid "Deselecting all matching images…"
 msgstr "Désélection de toutes les images correspondantes…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:767
+#: src/exif_turbo/ui/view_models/app_controller.py:772
 msgid "Inverting selection…"
 msgstr "Inversion de la sélection…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:781
+#: src/exif_turbo/ui/view_models/app_controller.py:786
 msgid "Selecting images without a cached thumbnail…"
 msgstr "Sélection des images sans miniature en cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:796
+#: src/exif_turbo/ui/view_models/app_controller.py:801
 msgid "No marked images to delete."
 msgstr "Aucune image marquée à supprimer."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:800
+#: src/exif_turbo/ui/view_models/app_controller.py:805
 msgid "Deleting marked images…"
 msgstr "Suppression des images marquées…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:810
+#: src/exif_turbo/ui/view_models/app_controller.py:815
 msgid "No marked images to export."
 msgstr "Aucune image marquée à exporter."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:815
+#: src/exif_turbo/ui/view_models/app_controller.py:820
 msgid "Exporting metadata…"
 msgstr "Exportation des métadonnées…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:917
+#: src/exif_turbo/ui/view_models/app_controller.py:922
 #, python-brace-format
 msgid "Deleted {n} image(s)."
 msgstr "{n} image(s) supprimée(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:921
+#: src/exif_turbo/ui/view_models/app_controller.py:926
 #, python-brace-format
 msgid "{n} were already missing."
 msgstr "{n} étaient déjà manquantes."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:927
+#: src/exif_turbo/ui/view_models/app_controller.py:932
 #, python-brace-format
 msgid "{n} could not be deleted."
 msgstr "{n} n’ont pas pu être supprimées."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:937
+#: src/exif_turbo/ui/view_models/app_controller.py:942
 #, python-brace-format
 msgid "Exported {count} image(s) to {name}"
 msgstr "{count} image(s) exportée(s) vers {name}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:946
-#: src/exif_turbo/ui/view_models/app_controller.py:1028
+#: src/exif_turbo/ui/view_models/app_controller.py:951
+#: src/exif_turbo/ui/view_models/app_controller.py:1033
 #, python-brace-format
 msgid "Operation failed: {}"
 msgstr "Opération échouée : {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:952
-#: src/exif_turbo/ui/view_models/app_controller.py:1034
+#: src/exif_turbo/ui/view_models/app_controller.py:957
+#: src/exif_turbo/ui/view_models/app_controller.py:1039
 msgid "Operation canceled."
 msgstr "Opération annulée."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1119
+#: src/exif_turbo/ui/view_models/app_controller.py:1125
 msgid "Wrong password — please try again."
 msgstr "Mot de passe incorrect — veuillez réessayer."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1131
+#: src/exif_turbo/ui/view_models/app_controller.py:1137
 #, python-brace-format
 msgid "Failed to open database: {error}"
 msgstr "Échec de l’ouverture de la base de données : {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1157
+#: src/exif_turbo/ui/view_models/app_controller.py:1163
 msgid "Database is locked."
 msgstr "La base de données est verrouillée."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1162
+#: src/exif_turbo/ui/view_models/app_controller.py:1168
 msgid "Cannot change password while indexing or thumb-building is running."
 msgstr ""
 "Impossible de changer le mot de passe pendant l’indexation ou la création"
 " des miniatures."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1166
+#: src/exif_turbo/ui/view_models/app_controller.py:1172
 msgid "Current password is incorrect."
 msgstr "Le mot de passe actuel est incorrect."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1169
+#: src/exif_turbo/ui/view_models/app_controller.py:1175
 msgid "New password must not be empty."
 msgstr "Le nouveau mot de passe ne doit pas être vide."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1173
+#: src/exif_turbo/ui/view_models/app_controller.py:1179
 msgid "New password must differ from the current password."
 msgstr "Le nouveau mot de passe doit être différent de l’actuel."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1191
+#: src/exif_turbo/ui/view_models/app_controller.py:1197
 msgid "Changing password…"
 msgstr "Changement du mot de passe…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1232
+#: src/exif_turbo/ui/view_models/app_controller.py:1238
 #, python-brace-format
 msgid "Database password changed, but reopening failed: {error}"
 msgstr ""
 "Mot de passe de la base de données modifié, mais la réouverture a échoué "
 ": {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1242
+#: src/exif_turbo/ui/view_models/app_controller.py:1248
 msgid "Password changed successfully."
 msgstr "Mot de passe modifié avec succès."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1283
+#: src/exif_turbo/ui/view_models/app_controller.py:1289
 #, python-brace-format
 msgid "Failed to change password: {error}"
 msgstr "Échec du changement de mot de passe : {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1288
+#: src/exif_turbo/ui/view_models/app_controller.py:1294
 #, python-brace-format
 msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
@@ -149,181 +149,189 @@ msgstr ""
 "Mot de passe modifié, mais le cache des miniatures n’a pas pu être "
 "rechiffré ({error}). Le cache a été effacé et sera reconstruit."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2080
+#: src/exif_turbo/ui/view_models/app_controller.py:2086
 msgid "Folder list reloaded."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2313
+#: src/exif_turbo/ui/view_models/app_controller.py:2319
 #, python-brace-format
 msgid "Folder already tracked: {}"
 msgstr "Dossier déjà suivi : {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2340
+#: src/exif_turbo/ui/view_models/app_controller.py:2346
 msgid "Removing folder…"
 msgstr "Suppression du dossier…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2512
+#: src/exif_turbo/ui/view_models/app_controller.py:2518
 msgid "Folder not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2518
+#: src/exif_turbo/ui/view_models/app_controller.py:2524
 #, python-brace-format
 msgid "Folder not accessible: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2557
+#: src/exif_turbo/ui/view_models/app_controller.py:2563
 #, python-brace-format
 msgid "Indexing {}…"
 msgstr "Indexation de {}…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2593
+#: src/exif_turbo/ui/view_models/app_controller.py:2599
 #, python-brace-format
 msgid "Indexed {count} images ({errors} skipped due to errors)"
 msgstr "{count} images indexées ({errors} ignorées en raison d’erreurs)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2598
+#: src/exif_turbo/ui/view_models/app_controller.py:2604
 #, python-brace-format
 msgid "Indexed {} images"
 msgstr "{} images indexées"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2631
+#: src/exif_turbo/ui/view_models/app_controller.py:2637
 #, python-brace-format
 msgid "Index failed: {}"
 msgstr "Indexation échouée : {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2663
+#: src/exif_turbo/ui/view_models/app_controller.py:2669
 msgid "Index canceled"
 msgstr "Indexation annulée"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2683
+#: src/exif_turbo/ui/view_models/app_controller.py:2689
 msgid "Canceling…"
 msgstr "Annulation…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2876
+#: src/exif_turbo/ui/view_models/app_controller.py:2882
 #, python-brace-format
 msgid "AI full rescan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2878
+#: src/exif_turbo/ui/view_models/app_controller.py:2884
 #, python-brace-format
 msgid "AI-Scan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2880
+#: src/exif_turbo/ui/view_models/app_controller.py:2886
 #, python-brace-format
 msgid "{n} file(s) could not be processed."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2887
+#: src/exif_turbo/ui/view_models/app_controller.py:2893
 #, python-brace-format
 msgid "AI full rescan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2889
+#: src/exif_turbo/ui/view_models/app_controller.py:2895
 #, python-brace-format
 msgid "AI-Scan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2896
+#: src/exif_turbo/ui/view_models/app_controller.py:2902
 #, python-brace-format
 msgid "AI full rescan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2900
+#: src/exif_turbo/ui/view_models/app_controller.py:2906
 #, python-brace-format
 msgid "AI-Scan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2926
+#: src/exif_turbo/ui/view_models/app_controller.py:2932
 #, python-brace-format
 msgid "Built {built} preview(s) of {total}."
 msgstr "{built} aperçu(s) créé(s) sur {total}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2930
+#: src/exif_turbo/ui/view_models/app_controller.py:2936
 #, python-brace-format
 msgid "{n} image(s) skipped — too large to decode safely."
 msgstr ""
 "{n} image(s) ignorée(s) — trop volumineuse(s) pour être décodée(s) sans "
 "risque."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2940
+#: src/exif_turbo/ui/view_models/app_controller.py:2946
 #, python-brace-format
 msgid "Preview build failed: {error}"
 msgstr "Création des aperçus échouée : {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2948
+#: src/exif_turbo/ui/view_models/app_controller.py:2954
 #, python-brace-format
 msgid "Preview build canceled ({built} of {total} done)."
 msgstr "Création des aperçus annulée ({built} sur {total} terminés)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2961
+#: src/exif_turbo/ui/view_models/app_controller.py:2967
 msgid "Cancel the running preview build before clearing the cache."
 msgstr "Annulez la création d’aperçus en cours avant de vider le cache."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2970
+#: src/exif_turbo/ui/view_models/app_controller.py:2976
 #, python-brace-format
 msgid "Failed to clear preview cache: {error}"
 msgstr "Échec du vidage du cache des aperçus : {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2976
+#: src/exif_turbo/ui/view_models/app_controller.py:2982
 #, python-brace-format
 msgid "Removed {n} cached preview(s)."
 msgstr "{n} aperçu(s) en cache supprimé(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3085
+#: src/exif_turbo/ui/view_models/app_controller.py:3091
 msgid "File not accessible — path copied"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3109
+#: src/exif_turbo/ui/view_models/app_controller.py:3115
 msgid "Image copied to clipboard"
 msgstr "Image copiée dans le presse-papiers"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3113
+#: src/exif_turbo/ui/view_models/app_controller.py:3119
 msgid "Path copied to clipboard"
 msgstr "Chemin copié dans le presse-papiers"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3122
-#: src/exif_turbo/ui/view_models/app_controller.py:3142
+#: src/exif_turbo/ui/view_models/app_controller.py:3128
+#: src/exif_turbo/ui/view_models/app_controller.py:3148
 msgid "File not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3131
+#: src/exif_turbo/ui/view_models/app_controller.py:3137
 msgid "Preview saved"
 msgstr "Prévisualisation enregistrée"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3147
+#: src/exif_turbo/ui/view_models/app_controller.py:3153
 msgid "Original saved"
 msgstr "Original enregistré"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3200
+#: src/exif_turbo/ui/view_models/app_controller.py:3206
 msgid "Resetting database…"
 msgstr "Réinitialisation de la base de données…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3223
+#: src/exif_turbo/ui/view_models/app_controller.py:3229
 msgid "Database reset"
 msgstr "Base de données réinitialisée"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3240
-#: src/exif_turbo/ui/view_models/app_controller.py:3252
+#: src/exif_turbo/ui/view_models/app_controller.py:3323
+#, python-brace-format
+msgid ""
+"Original data source not attached: {source} — attach or mount this folder"
+" to open files."
+msgstr ""
+"Source de données d'origine non rattachée : {source} — rattachez ou "
+"montez ce dossier pour ouvrir les fichiers."
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3330
 #, python-brace-format
 msgid "File not found: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3418
+#: src/exif_turbo/ui/view_models/app_controller.py:3476
 msgid "Cleaning up cache…"
 msgstr "Nettoyage du cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3438
+#: src/exif_turbo/ui/view_models/app_controller.py:3496
 #, python-brace-format
 msgid "Indexing… {} (scanning)"
 msgstr "Indexation… {} (analyse)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3440
+#: src/exif_turbo/ui/view_models/app_controller.py:3498
 #, python-brace-format
 msgid "Indexing… 0 / {}"
 msgstr "Indexation… 0 / {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3442
+#: src/exif_turbo/ui/view_models/app_controller.py:3500
 #, python-brace-format
 msgid "Indexing… {} / {}"
 msgstr "Indexation… {} / {}"

--- a/src/exif_turbo/i18n/locales/it/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/it/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-28 19:41+0200\n"
+"POT-Creation-Date: 2026-06-29 20:42+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: it\n"
@@ -26,119 +26,119 @@ msgstr "PyTorch non è disponibile su macOS Intel per Python 3.13+."
 msgid "Enter the database password to continue"
 msgstr "Inserisci la password del database per continuare"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:747
+#: src/exif_turbo/ui/view_models/app_controller.py:752
 msgid "Selecting all matching images…"
 msgstr "Selezione di tutte le immagini corrispondenti…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:757
+#: src/exif_turbo/ui/view_models/app_controller.py:762
 msgid "Deselecting all matching images…"
 msgstr "Deselezione di tutte le immagini corrispondenti…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:767
+#: src/exif_turbo/ui/view_models/app_controller.py:772
 msgid "Inverting selection…"
 msgstr "Inversione della selezione…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:781
+#: src/exif_turbo/ui/view_models/app_controller.py:786
 msgid "Selecting images without a cached thumbnail…"
 msgstr "Selezione delle immagini senza miniatura nella cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:796
+#: src/exif_turbo/ui/view_models/app_controller.py:801
 msgid "No marked images to delete."
 msgstr "Nessuna immagine contrassegnata da eliminare."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:800
+#: src/exif_turbo/ui/view_models/app_controller.py:805
 msgid "Deleting marked images…"
 msgstr "Eliminazione delle immagini contrassegnate…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:810
+#: src/exif_turbo/ui/view_models/app_controller.py:815
 msgid "No marked images to export."
 msgstr "Nessuna immagine contrassegnata da esportare."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:815
+#: src/exif_turbo/ui/view_models/app_controller.py:820
 msgid "Exporting metadata…"
 msgstr "Esportazione metadati…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:917
+#: src/exif_turbo/ui/view_models/app_controller.py:922
 #, python-brace-format
 msgid "Deleted {n} image(s)."
 msgstr "{n} immagine/i eliminata/e."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:921
+#: src/exif_turbo/ui/view_models/app_controller.py:926
 #, python-brace-format
 msgid "{n} were already missing."
 msgstr "{n} erano già mancanti."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:927
+#: src/exif_turbo/ui/view_models/app_controller.py:932
 #, python-brace-format
 msgid "{n} could not be deleted."
 msgstr "{n} non è/sono potuta/e essere eliminata/e."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:937
+#: src/exif_turbo/ui/view_models/app_controller.py:942
 #, python-brace-format
 msgid "Exported {count} image(s) to {name}"
 msgstr "{count} immagine/i esportata/e in {name}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:946
-#: src/exif_turbo/ui/view_models/app_controller.py:1028
+#: src/exif_turbo/ui/view_models/app_controller.py:951
+#: src/exif_turbo/ui/view_models/app_controller.py:1033
 #, python-brace-format
 msgid "Operation failed: {}"
 msgstr "Operazione fallita: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:952
-#: src/exif_turbo/ui/view_models/app_controller.py:1034
+#: src/exif_turbo/ui/view_models/app_controller.py:957
+#: src/exif_turbo/ui/view_models/app_controller.py:1039
 msgid "Operation canceled."
 msgstr "Operazione annullata."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1119
+#: src/exif_turbo/ui/view_models/app_controller.py:1125
 msgid "Wrong password — please try again."
 msgstr "Password errata — riprova."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1131
+#: src/exif_turbo/ui/view_models/app_controller.py:1137
 #, python-brace-format
 msgid "Failed to open database: {error}"
 msgstr "Impossibile aprire il database: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1157
+#: src/exif_turbo/ui/view_models/app_controller.py:1163
 msgid "Database is locked."
 msgstr "Il database è bloccato."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1162
+#: src/exif_turbo/ui/view_models/app_controller.py:1168
 msgid "Cannot change password while indexing or thumb-building is running."
 msgstr ""
 "Impossibile cambiare la password mentre è in corso l’indicizzazione o la "
 "creazione delle miniature."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1166
+#: src/exif_turbo/ui/view_models/app_controller.py:1172
 msgid "Current password is incorrect."
 msgstr "La password attuale non è corretta."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1169
+#: src/exif_turbo/ui/view_models/app_controller.py:1175
 msgid "New password must not be empty."
 msgstr "La nuova password non può essere vuota."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1173
+#: src/exif_turbo/ui/view_models/app_controller.py:1179
 msgid "New password must differ from the current password."
 msgstr "La nuova password deve essere diversa da quella attuale."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1191
+#: src/exif_turbo/ui/view_models/app_controller.py:1197
 msgid "Changing password…"
 msgstr "Modifica password in corso…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1232
+#: src/exif_turbo/ui/view_models/app_controller.py:1238
 #, python-brace-format
 msgid "Database password changed, but reopening failed: {error}"
 msgstr "Password del database modificata, ma la riapertura non è riuscita: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1242
+#: src/exif_turbo/ui/view_models/app_controller.py:1248
 msgid "Password changed successfully."
 msgstr "Password modificata correttamente."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1283
+#: src/exif_turbo/ui/view_models/app_controller.py:1289
 #, python-brace-format
 msgid "Failed to change password: {error}"
 msgstr "Modifica password non riuscita: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1288
+#: src/exif_turbo/ui/view_models/app_controller.py:1294
 #, python-brace-format
 msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
@@ -147,181 +147,189 @@ msgstr ""
 "La password è stata modificata ma la cache delle miniature non è stata "
 "ricifrata ({error}). La cache è stata svuotata e verrà ricostruita."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2080
+#: src/exif_turbo/ui/view_models/app_controller.py:2086
 msgid "Folder list reloaded."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2313
+#: src/exif_turbo/ui/view_models/app_controller.py:2319
 #, python-brace-format
 msgid "Folder already tracked: {}"
 msgstr "Cartella già monitorata: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2340
+#: src/exif_turbo/ui/view_models/app_controller.py:2346
 msgid "Removing folder…"
 msgstr "Rimozione della cartella…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2512
+#: src/exif_turbo/ui/view_models/app_controller.py:2518
 msgid "Folder not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2518
+#: src/exif_turbo/ui/view_models/app_controller.py:2524
 #, python-brace-format
 msgid "Folder not accessible: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2557
+#: src/exif_turbo/ui/view_models/app_controller.py:2563
 #, python-brace-format
 msgid "Indexing {}…"
 msgstr "Indicizzazione {}…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2593
+#: src/exif_turbo/ui/view_models/app_controller.py:2599
 #, python-brace-format
 msgid "Indexed {count} images ({errors} skipped due to errors)"
 msgstr "{count} immagini indicizzate ({errors} saltate a causa di errori)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2598
+#: src/exif_turbo/ui/view_models/app_controller.py:2604
 #, python-brace-format
 msgid "Indexed {} images"
 msgstr "{} immagini indicizzate"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2631
+#: src/exif_turbo/ui/view_models/app_controller.py:2637
 #, python-brace-format
 msgid "Index failed: {}"
 msgstr "Indicizzazione fallita: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2663
+#: src/exif_turbo/ui/view_models/app_controller.py:2669
 msgid "Index canceled"
 msgstr "Indicizzazione annullata"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2683
+#: src/exif_turbo/ui/view_models/app_controller.py:2689
 msgid "Canceling…"
 msgstr "Annullamento…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2876
+#: src/exif_turbo/ui/view_models/app_controller.py:2882
 #, python-brace-format
 msgid "AI full rescan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2878
+#: src/exif_turbo/ui/view_models/app_controller.py:2884
 #, python-brace-format
 msgid "AI-Scan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2880
+#: src/exif_turbo/ui/view_models/app_controller.py:2886
 #, python-brace-format
 msgid "{n} file(s) could not be processed."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2887
+#: src/exif_turbo/ui/view_models/app_controller.py:2893
 #, python-brace-format
 msgid "AI full rescan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2889
+#: src/exif_turbo/ui/view_models/app_controller.py:2895
 #, python-brace-format
 msgid "AI-Scan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2896
+#: src/exif_turbo/ui/view_models/app_controller.py:2902
 #, python-brace-format
 msgid "AI full rescan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2900
+#: src/exif_turbo/ui/view_models/app_controller.py:2906
 #, python-brace-format
 msgid "AI-Scan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2926
+#: src/exif_turbo/ui/view_models/app_controller.py:2932
 #, python-brace-format
 msgid "Built {built} preview(s) of {total}."
 msgstr "{built} anteprima/e create di {total}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2930
+#: src/exif_turbo/ui/view_models/app_controller.py:2936
 #, python-brace-format
 msgid "{n} image(s) skipped — too large to decode safely."
 msgstr ""
 "{n} immagine/i saltata/e — troppo grande/i per essere decodificata/e in "
 "sicurezza."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2940
+#: src/exif_turbo/ui/view_models/app_controller.py:2946
 #, python-brace-format
 msgid "Preview build failed: {error}"
 msgstr "Creazione anteprime non riuscita: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2948
+#: src/exif_turbo/ui/view_models/app_controller.py:2954
 #, python-brace-format
 msgid "Preview build canceled ({built} of {total} done)."
 msgstr "Creazione anteprime annullata ({built} di {total} completate)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2961
+#: src/exif_turbo/ui/view_models/app_controller.py:2967
 msgid "Cancel the running preview build before clearing the cache."
 msgstr "Annulla la creazione delle anteprime in corso prima di svuotare la cache."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2970
+#: src/exif_turbo/ui/view_models/app_controller.py:2976
 #, python-brace-format
 msgid "Failed to clear preview cache: {error}"
 msgstr "Impossibile svuotare la cache delle anteprime: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2976
+#: src/exif_turbo/ui/view_models/app_controller.py:2982
 #, python-brace-format
 msgid "Removed {n} cached preview(s)."
 msgstr "{n} anteprima/e in cache rimossa/e."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3085
+#: src/exif_turbo/ui/view_models/app_controller.py:3091
 msgid "File not accessible — path copied"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3109
+#: src/exif_turbo/ui/view_models/app_controller.py:3115
 msgid "Image copied to clipboard"
 msgstr "Immagine copiata negli appunti"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3113
+#: src/exif_turbo/ui/view_models/app_controller.py:3119
 msgid "Path copied to clipboard"
 msgstr "Percorso copiato negli appunti"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3122
-#: src/exif_turbo/ui/view_models/app_controller.py:3142
+#: src/exif_turbo/ui/view_models/app_controller.py:3128
+#: src/exif_turbo/ui/view_models/app_controller.py:3148
 msgid "File not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3131
+#: src/exif_turbo/ui/view_models/app_controller.py:3137
 msgid "Preview saved"
 msgstr "Anteprima salvata"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3147
+#: src/exif_turbo/ui/view_models/app_controller.py:3153
 msgid "Original saved"
 msgstr "Originale salvato"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3200
+#: src/exif_turbo/ui/view_models/app_controller.py:3206
 msgid "Resetting database…"
 msgstr "Ripristino del database…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3223
+#: src/exif_turbo/ui/view_models/app_controller.py:3229
 msgid "Database reset"
 msgstr "Database ripristinato"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3240
-#: src/exif_turbo/ui/view_models/app_controller.py:3252
+#: src/exif_turbo/ui/view_models/app_controller.py:3323
+#, python-brace-format
+msgid ""
+"Original data source not attached: {source} — attach or mount this folder"
+" to open files."
+msgstr ""
+"Origine dati originale non collegata: {source} — collega o monta questa "
+"cartella per aprire i file."
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3330
 #, python-brace-format
 msgid "File not found: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3418
+#: src/exif_turbo/ui/view_models/app_controller.py:3476
 msgid "Cleaning up cache…"
 msgstr "Pulizia della cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3438
+#: src/exif_turbo/ui/view_models/app_controller.py:3496
 #, python-brace-format
 msgid "Indexing… {} (scanning)"
 msgstr "Indicizzazione… {} (scansione)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3440
+#: src/exif_turbo/ui/view_models/app_controller.py:3498
 #, python-brace-format
 msgid "Indexing… 0 / {}"
 msgstr "Indicizzazione… 0 / {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3442
+#: src/exif_turbo/ui/view_models/app_controller.py:3500
 #, python-brace-format
 msgid "Indexing… {} / {}"
 msgstr "Indicizzazione… {} / {}"

--- a/src/exif_turbo/i18n/locales/rm/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/rm/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-06-28 19:41+0200\n"
+"POT-Creation-Date: 2026-06-29 20:42+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: rm\n"
@@ -26,121 +26,121 @@ msgstr "PyTorch na è betg disponibel sin macOS Intel per Python 3.13+."
 msgid "Enter the database password to continue"
 msgstr "Endatar la pled-clav da la banca da datas per cuntinuar"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:747
+#: src/exif_turbo/ui/view_models/app_controller.py:752
 msgid "Selecting all matching images…"
 msgstr "Seleziun da tuts ils maletgs correspundentas…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:757
+#: src/exif_turbo/ui/view_models/app_controller.py:762
 msgid "Deselecting all matching images…"
 msgstr "Deseleziun da tuts ils maletgs correspundentas…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:767
+#: src/exif_turbo/ui/view_models/app_controller.py:772
 msgid "Inverting selection…"
 msgstr "Inversiun da la selecziun…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:781
+#: src/exif_turbo/ui/view_models/app_controller.py:786
 msgid "Selecting images without a cached thumbnail…"
 msgstr "Seleziun da maletgs senza miniatura en il cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:796
+#: src/exif_turbo/ui/view_models/app_controller.py:801
 msgid "No marked images to delete."
 msgstr "Nagins maletgs marcads per stizzar."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:800
+#: src/exif_turbo/ui/view_models/app_controller.py:805
 msgid "Deleting marked images…"
 msgstr "Maletgs marcads vegnan stizzads…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:810
+#: src/exif_turbo/ui/view_models/app_controller.py:815
 msgid "No marked images to export."
 msgstr "Nagins maletgs marcads per exportar."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:815
+#: src/exif_turbo/ui/view_models/app_controller.py:820
 msgid "Exporting metadata…"
 msgstr "Exportaziun da metadata…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:917
+#: src/exif_turbo/ui/view_models/app_controller.py:922
 #, python-brace-format
 msgid "Deleted {n} image(s)."
 msgstr "{n} maletg(s) stizzad(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:921
+#: src/exif_turbo/ui/view_models/app_controller.py:926
 #, python-brace-format
 msgid "{n} were already missing."
 msgstr "{n} eran gia betg chattabels."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:927
+#: src/exif_turbo/ui/view_models/app_controller.py:932
 #, python-brace-format
 msgid "{n} could not be deleted."
 msgstr "{n} n’han betg pudì vegnir stizzads."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:937
+#: src/exif_turbo/ui/view_models/app_controller.py:942
 #, python-brace-format
 msgid "Exported {count} image(s) to {name}"
 msgstr "{count} maletg(s) exportad(s) en {name}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:946
-#: src/exif_turbo/ui/view_models/app_controller.py:1028
+#: src/exif_turbo/ui/view_models/app_controller.py:951
+#: src/exif_turbo/ui/view_models/app_controller.py:1033
 #, python-brace-format
 msgid "Operation failed: {}"
 msgstr "Operaziun buca reussida: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:952
-#: src/exif_turbo/ui/view_models/app_controller.py:1034
+#: src/exif_turbo/ui/view_models/app_controller.py:957
+#: src/exif_turbo/ui/view_models/app_controller.py:1039
 msgid "Operation canceled."
 msgstr "Operaziun annullada."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1119
+#: src/exif_turbo/ui/view_models/app_controller.py:1125
 msgid "Wrong password — please try again."
 msgstr "Pled-clav fauss — emprova p.pl. anc ina giada."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1131
+#: src/exif_turbo/ui/view_models/app_controller.py:1137
 #, python-brace-format
 msgid "Failed to open database: {error}"
 msgstr "Impussibel da rir la banca da datas: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1157
+#: src/exif_turbo/ui/view_models/app_controller.py:1163
 msgid "Database is locked."
 msgstr "La banca da datas è serrada."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1162
+#: src/exif_turbo/ui/view_models/app_controller.py:1168
 msgid "Cannot change password while indexing or thumb-building is running."
 msgstr ""
 "Impussibel da midar la pled-clav durant l’indexaziun u la creaziun da "
 "miniaturas."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1166
+#: src/exif_turbo/ui/view_models/app_controller.py:1172
 msgid "Current password is incorrect."
 msgstr "La pled-clav actuala n’è betg correcta."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1169
+#: src/exif_turbo/ui/view_models/app_controller.py:1175
 msgid "New password must not be empty."
 msgstr "La nova pled-clav na dastga betg esser vida."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1173
+#: src/exif_turbo/ui/view_models/app_controller.py:1179
 msgid "New password must differ from the current password."
 msgstr "La nova pled-clav sto esser differenta da quella actuala."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1191
+#: src/exif_turbo/ui/view_models/app_controller.py:1197
 msgid "Changing password…"
 msgstr "Pled-clav vegn midada…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1232
+#: src/exif_turbo/ui/view_models/app_controller.py:1238
 #, python-brace-format
 msgid "Database password changed, but reopening failed: {error}"
 msgstr ""
 "La pled-clav da la banca da datas è vegnida midada, ma la reaviertura n’è"
 " betg reussida: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1242
+#: src/exif_turbo/ui/view_models/app_controller.py:1248
 msgid "Password changed successfully."
 msgstr "Pled-clav midada cun success."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1283
+#: src/exif_turbo/ui/view_models/app_controller.py:1289
 #, python-brace-format
 msgid "Failed to change password: {error}"
 msgstr "Midada da la pled-clav betg reussida: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1288
+#: src/exif_turbo/ui/view_models/app_controller.py:1294
 #, python-brace-format
 msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
@@ -149,179 +149,187 @@ msgstr ""
 "La pled-clav è vegnida midada, ma il cache da miniaturas n’è betg pudida "
 "vegnir cifrada da nov ({error}). Il cache è vegnì stizzad e vegn rebatgì."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2080
+#: src/exif_turbo/ui/view_models/app_controller.py:2086
 msgid "Folder list reloaded."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2313
+#: src/exif_turbo/ui/view_models/app_controller.py:2319
 #, python-brace-format
 msgid "Folder already tracked: {}"
 msgstr "Cartella gia trackata: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2340
+#: src/exif_turbo/ui/view_models/app_controller.py:2346
 msgid "Removing folder…"
 msgstr "Allontanar la cartella…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2512
+#: src/exif_turbo/ui/view_models/app_controller.py:2518
 msgid "Folder not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2518
+#: src/exif_turbo/ui/view_models/app_controller.py:2524
 #, python-brace-format
 msgid "Folder not accessible: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2557
+#: src/exif_turbo/ui/view_models/app_controller.py:2563
 #, python-brace-format
 msgid "Indexing {}…"
 msgstr "Indexaziun {}…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2593
+#: src/exif_turbo/ui/view_models/app_controller.py:2599
 #, python-brace-format
 msgid "Indexed {count} images ({errors} skipped due to errors)"
 msgstr "{count} maletgs indexads ({errors} sursiglids pervia d’errurs)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2598
+#: src/exif_turbo/ui/view_models/app_controller.py:2604
 #, python-brace-format
 msgid "Indexed {} images"
 msgstr "{} maletgs indexads"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2631
+#: src/exif_turbo/ui/view_models/app_controller.py:2637
 #, python-brace-format
 msgid "Index failed: {}"
 msgstr "Indexaziun buca reussida: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2663
+#: src/exif_turbo/ui/view_models/app_controller.py:2669
 msgid "Index canceled"
 msgstr "Indexaziun interrutta"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2683
+#: src/exif_turbo/ui/view_models/app_controller.py:2689
 msgid "Canceling…"
 msgstr "Interruziun…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2876
+#: src/exif_turbo/ui/view_models/app_controller.py:2882
 #, python-brace-format
 msgid "AI full rescan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2878
+#: src/exif_turbo/ui/view_models/app_controller.py:2884
 #, python-brace-format
 msgid "AI-Scan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2880
+#: src/exif_turbo/ui/view_models/app_controller.py:2886
 #, python-brace-format
 msgid "{n} file(s) could not be processed."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2887
+#: src/exif_turbo/ui/view_models/app_controller.py:2893
 #, python-brace-format
 msgid "AI full rescan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2889
+#: src/exif_turbo/ui/view_models/app_controller.py:2895
 #, python-brace-format
 msgid "AI-Scan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2896
+#: src/exif_turbo/ui/view_models/app_controller.py:2902
 #, python-brace-format
 msgid "AI full rescan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2900
+#: src/exif_turbo/ui/view_models/app_controller.py:2906
 #, python-brace-format
 msgid "AI-Scan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2926
+#: src/exif_turbo/ui/view_models/app_controller.py:2932
 #, python-brace-format
 msgid "Built {built} preview(s) of {total}."
 msgstr "{built} prevista(s) da {total} creada(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2930
+#: src/exif_turbo/ui/view_models/app_controller.py:2936
 #, python-brace-format
 msgid "{n} image(s) skipped — too large to decode safely."
 msgstr "{n} maletg(s) sursiglid(s) — memia gronds per decodar senza riscu."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2940
+#: src/exif_turbo/ui/view_models/app_controller.py:2946
 #, python-brace-format
 msgid "Preview build failed: {error}"
 msgstr "Creaziun da previstas buca reussida: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2948
+#: src/exif_turbo/ui/view_models/app_controller.py:2954
 #, python-brace-format
 msgid "Preview build canceled ({built} of {total} done)."
 msgstr "Creaziun da previstas interrutta ({built} da {total} fatg)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2961
+#: src/exif_turbo/ui/view_models/app_controller.py:2967
 msgid "Cancel the running preview build before clearing the cache."
 msgstr "Interrumper la creaziun da previstas en cors avant da stizzar il cache."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2970
+#: src/exif_turbo/ui/view_models/app_controller.py:2976
 #, python-brace-format
 msgid "Failed to clear preview cache: {error}"
 msgstr "Stizzar il cache da previstas n’è betg reussì: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2976
+#: src/exif_turbo/ui/view_models/app_controller.py:2982
 #, python-brace-format
 msgid "Removed {n} cached preview(s)."
 msgstr "{n} prevista(s) dal cache vegnida(s) stizzada(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3085
+#: src/exif_turbo/ui/view_models/app_controller.py:3091
 msgid "File not accessible — path copied"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3109
+#: src/exif_turbo/ui/view_models/app_controller.py:3115
 msgid "Image copied to clipboard"
 msgstr "Maletg copià en la tavla d’interscambi"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3113
+#: src/exif_turbo/ui/view_models/app_controller.py:3119
 msgid "Path copied to clipboard"
 msgstr "Traject copià en la tavla d’interscambi"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3122
-#: src/exif_turbo/ui/view_models/app_controller.py:3142
+#: src/exif_turbo/ui/view_models/app_controller.py:3128
+#: src/exif_turbo/ui/view_models/app_controller.py:3148
 msgid "File not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3131
+#: src/exif_turbo/ui/view_models/app_controller.py:3137
 msgid "Preview saved"
 msgstr "Prevista memorisada"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3147
+#: src/exif_turbo/ui/view_models/app_controller.py:3153
 msgid "Original saved"
 msgstr "Original memorisà"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3200
+#: src/exif_turbo/ui/view_models/app_controller.py:3206
 msgid "Resetting database…"
 msgstr "Reinizialisar la banca da datas…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3223
+#: src/exif_turbo/ui/view_models/app_controller.py:3229
 msgid "Database reset"
 msgstr "Banca da datas resettada"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3240
-#: src/exif_turbo/ui/view_models/app_controller.py:3252
+#: src/exif_turbo/ui/view_models/app_controller.py:3323
+#, python-brace-format
+msgid ""
+"Original data source not attached: {source} — attach or mount this folder"
+" to open files."
+msgstr ""
+"Funtauna da datas originala betg colliada: {source} — colliai u montai "
+"questa cartella per avrir datotecas."
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3330
 #, python-brace-format
 msgid "File not found: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3418
+#: src/exif_turbo/ui/view_models/app_controller.py:3476
 msgid "Cleaning up cache…"
 msgstr "Stizzar il cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3438
+#: src/exif_turbo/ui/view_models/app_controller.py:3496
 #, python-brace-format
 msgid "Indexing… {} (scanning)"
 msgstr "Indexaziun… {} (tscherta)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3440
+#: src/exif_turbo/ui/view_models/app_controller.py:3498
 #, python-brace-format
 msgid "Indexing… 0 / {}"
 msgstr "Indexaziun… 0 / {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3442
+#: src/exif_turbo/ui/view_models/app_controller.py:3500
 #, python-brace-format
 msgid "Indexing… {} / {}"
 msgstr "Indexaziun… {} / {}"

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -4800,7 +4800,9 @@ ApplicationWindow {
             }
             text: _statusText
             font.pixelSize: 11
-            opacity: 0.7
+            color: (controller && controller.statusIsError)
+                   ? Material.color(Material.Red) : Material.foreground
+            opacity: (controller && controller.statusIsError) ? 1.0 : 0.7
         }
     }
 }

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -173,6 +173,7 @@ class AppController(QObject):
         self._exif_model = exif_model
         self._folder_model = folder_model
         self._status_text = _("Enter the database password to continue")
+        self._status_is_error = False
         self._is_locked = True
         self._is_new_database = not db_path.exists()
         self._unlock_error = ""
@@ -366,6 +367,10 @@ class AppController(QObject):
     @Property(str, notify=statusTextChanged)
     def statusText(self) -> str:
         return self._status_text
+
+    @Property(bool, notify=statusTextChanged)
+    def statusIsError(self) -> bool:
+        return self._status_is_error
 
     @Property(bool, notify=isIndexingChanged)
     def isIndexing(self) -> bool:
@@ -1067,6 +1072,7 @@ class AppController(QObject):
             self._date_from = None
             self._date_to = None
             self._status_text = ""
+            self._status_is_error = False
             self._is_unlocking = False
             self.isUnlockingChanged.emit()
             # Wipe plain PNG thumbs on first unlock with a password (one-time migration
@@ -3237,7 +3243,7 @@ class AppController(QObject):
         if not path:
             return
         if not os.path.exists(path):
-            self._set_status(_("File not found: {}").format(Path(path).name))
+            self._warn_unavailable(path)
             return
         if sys.platform == "linux":
             subprocess.Popen(["xdg-open", path], env=_pyinstaller_clean_env())
@@ -3249,7 +3255,7 @@ class AppController(QObject):
         if not path:
             return
         if not os.path.exists(path):
-            self._set_status(_("File not found: {}").format(Path(path).name))
+            self._warn_unavailable(path)
             return
         if os.name == "nt":
             # /select,"<path>" must be passed as a shell string so the quoted
@@ -3268,10 +3274,62 @@ class AppController(QObject):
 
     # ── Private helpers ───────────────────────────────────────────────────────
 
-    def _set_status(self, text: str) -> None:
-        if self._status_text != text:
+    def _set_status(self, text: str, *, error: bool = False) -> None:
+        if self._status_text != text or self._status_is_error != error:
             self._status_text = text
+            self._status_is_error = error
             self.statusTextChanged.emit()
+
+    def _expected_data_source(self, path: str) -> str:
+        """Return the indexed-folder root that should contain *path*, or "".
+
+        When an indexed file cannot be opened because its original location is
+        unavailable, this points the user at the folder they need to (re)attach
+        or mount.  The longest matching indexed-folder root wins so nested
+        folders are reported precisely.  Returns "" when no managed folder
+        covers *path* (so we never guess a path the app does not know).
+        """
+        if self._folder_repo is None:
+            return ""
+        try:
+            target = os.path.normcase(os.path.normpath(path))
+        except (OSError, ValueError):
+            return ""
+        best_root = ""
+        best_len = -1
+        for folder in self._folder_repo.get_all():
+            root_raw = os.path.normpath(folder.path)
+            root = os.path.normcase(root_raw)
+            try:
+                common = os.path.commonpath([root, target])
+            except ValueError:
+                # Different drives / unrelated roots (e.g. C: vs D: on Windows).
+                continue
+            if common == root and len(root) > best_len:
+                best_root = root_raw
+                best_len = len(root)
+        return best_root
+
+    def _warn_unavailable(self, path: str) -> None:
+        """Show a red status-bar warning for an unavailable indexed file.
+
+        If the file belongs to a known indexed folder, hint which data source
+        to attach; otherwise fall back to a plain file-not-found message.
+        """
+        source = self._expected_data_source(path)
+        if source:
+            self._set_status(
+                _(
+                    "Original data source not attached: {source} — "
+                    "attach or mount this folder to open files."
+                ).format(source=source),
+                error=True,
+            )
+        else:
+            self._set_status(
+                _("File not found: {}").format(Path(path).name),
+                error=True,
+            )
 
     def _clear_details(self) -> None:
         self._preview_delay_timer.stop()

--- a/tests/ui/test_open_image_unavailable.py
+++ b/tests/ui/test_open_image_unavailable.py
@@ -1,0 +1,137 @@
+"""Unit tests for AppController file-open behaviour when the original is gone.
+
+Covers issue #20: clicking a thumbnail whose original data source is not
+attached must not silently fail.  Instead the controller surfaces a red
+status-bar warning that names the indexed folder the user needs to (re)attach
+or mount, and it never tries to open a missing file.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Generator
+
+import pytest
+
+from exif_turbo.ui.models.exif_list_model import ExifListModel
+from exif_turbo.ui.models.folder_list_model import FolderListModel
+from exif_turbo.ui.models.search_list_model import SearchListModel
+from exif_turbo.ui.view_models.app_controller import AppController
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def controller(tmp_path: Path) -> Generator[AppController, None, None]:
+    """Bare AppController over an unopened DB — no QML engine, no workers."""
+    search_model = SearchListModel(cache_dir=tmp_path / "thumbs")
+    ctrl = AppController(
+        tmp_path / "app.db",
+        search_model,
+        ExifListModel(),
+        FolderListModel(),
+    )
+    yield ctrl
+    ctrl.close()
+
+
+def _fake_folder_repo(*paths: str) -> SimpleNamespace:
+    """In-memory stand-in for IndexedFolderRepository exposing get_all/close."""
+    folders = [SimpleNamespace(path=p) for p in paths]
+    return SimpleNamespace(get_all=lambda: folders, close=lambda: None)
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+
+def test_openImage_missing_file_in_indexed_folder_warns_with_data_source(
+    controller: AppController, tmp_path: Path
+) -> None:
+    # Arrange — folder is indexed but the file no longer exists on disk
+    root = tmp_path / "photos"
+    controller._folder_repo = _fake_folder_repo(str(root))
+    missing = root / "sub" / "img.jpg"
+
+    # Act
+    controller.openImage(str(missing))
+
+    # Assert — red warning naming the data source to attach
+    assert controller.statusIsError is True
+    assert os.path.normpath(str(root)) in controller.statusText
+
+
+def test_openImage_missing_file_outside_indexed_folders_warns_file_not_found(
+    controller: AppController, tmp_path: Path
+) -> None:
+    # Arrange — missing file is not covered by any indexed folder
+    controller._folder_repo = _fake_folder_repo(str(tmp_path / "photos"))
+    missing = tmp_path / "elsewhere" / "img.jpg"
+
+    # Act
+    controller.openImage(str(missing))
+
+    # Assert — still an error, but the generic file-not-found message
+    assert controller.statusIsError is True
+    assert "img.jpg" in controller.statusText
+
+
+def test_openFolder_missing_file_in_indexed_folder_warns_with_data_source(
+    controller: AppController, tmp_path: Path
+) -> None:
+    # Arrange
+    root = tmp_path / "photos"
+    controller._folder_repo = _fake_folder_repo(str(root))
+    missing = root / "img.jpg"
+
+    # Act
+    controller.openFolder(str(missing))
+
+    # Assert
+    assert controller.statusIsError is True
+    assert os.path.normpath(str(root)) in controller.statusText
+
+
+def test_expected_data_source_returns_longest_matching_root(
+    controller: AppController, tmp_path: Path
+) -> None:
+    # Arrange — nested indexed roots; the deeper one must win
+    outer = tmp_path / "lib"
+    inner = tmp_path / "lib" / "2024"
+    controller._folder_repo = _fake_folder_repo(str(outer), str(inner))
+    target = inner / "img.jpg"
+
+    # Act
+    source = controller._expected_data_source(str(target))
+
+    # Assert
+    assert source == os.path.normpath(str(inner))
+
+
+def test_expected_data_source_no_indexed_folder_returns_empty(
+    controller: AppController, tmp_path: Path
+) -> None:
+    # Arrange
+    controller._folder_repo = _fake_folder_repo(str(tmp_path / "photos"))
+
+    # Act
+    source = controller._expected_data_source(str(tmp_path / "other" / "img.jpg"))
+
+    # Assert
+    assert source == ""
+
+
+def test_openImage_empty_path_leaves_status_unchanged(
+    controller: AppController,
+) -> None:
+    # Arrange
+    before = controller.statusText
+
+    # Act
+    controller.openImage("")
+
+    # Assert
+    assert controller.statusIsError is False
+    assert controller.statusText == before


### PR DESCRIPTION
## Summary

Opening or revealing an indexed file whose original folder is unavailable (e.g. an external drive that isn't mounted/attached) now shows a **red status-bar warning** naming the indexed-folder root the user needs to (re)attach or mount, instead of a generic file-not-found message.

## Changes

- Add `statusIsError` property on `AppController` and color the status bar red when set.
- Add `_expected_data_source` / `_warn_unavailable` helpers that map an unavailable path back to its longest-matching indexed-folder root.
- Wire `openImage` / `revealImage` to the new warning path.
- Add translations (de, fr, it, rm) for the new message.
- Update the user manual.
- Add `tests/ui/test_open_image_unavailable.py`.