### PR TITLE
chore: release v1.14.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "exif-turbo"
-version = "1.14.12"
+version = "1.14.13"
 description = "Fast EXIF full-text search with a PySide6 UI"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/exif_turbo/__init__.py
+++ b/src/exif_turbo/__init__.py
@@ -1,6 +1,6 @@
 """exif-turbo — Cross-platform image EXIF metadata search and indexing tool."""
 
-__version__ = "1.14.12"
+__version__ = "1.14.13"
 
 from .data.image_index_repository import ImageIndexRepository
 from .indexing.exif_metadata_extractor import ExifMetadataExtractor

--- a/version_info.py
+++ b/version_info.py
@@ -1,8 +1,8 @@
 # Auto-generated from exif-turbo.spec — do not edit manually.
 VSVersionInfo(
     ffi=FixedFileInfo(
-        filevers=(1, 14, 12, 0),
-        prodvers=(1, 14, 12, 0),
+        filevers=(1, 14, 13, 0),
+        prodvers=(1, 14, 13, 0),
         mask=0x3F,
         flags=0x0,
         OS=0x40004,
@@ -18,12 +18,12 @@ VSVersionInfo(
                     [
                         StringStruct("CompanyName", "exif-turbo"),
                         StringStruct("FileDescription", "exif-turbo — Image EXIF metadata search and indexing tool"),
-                        StringStruct("FileVersion", "1.14.12"),
+                        StringStruct("FileVersion", "1.14.13"),
                         StringStruct("InternalName", "exif-turbo"),
                         StringStruct("LegalCopyright", "Copyright (c) 2025 exif-turbo contributors"),
                         StringStruct("OriginalFilename", "exif-turbo.exe"),
                         StringStruct("ProductName", "exif-turbo"),
-                        StringStruct("ProductVersion", "1.14.12"),
+                        StringStruct("ProductVersion", "1.14.13"),
                     ],
                 )
             ]


### PR DESCRIPTION
Version bump to 1.14.13 (auto-generated by the release workflow).

- src/exif_turbo/__init__.py
- pyproject.toml
- version_info.py

Tag v1.14.13 and the GitHub Release are already published. This PR brings main in sync with the released version using signed, verified commits.