### PR TITLE
chore: update dependencies to latest stable + harden test suite

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,52 @@ pytest -x           # Stop on first failure
 pytest --tb=short   # Shorter tracebacks
 ```
 
+### Running the full suite reliably (agent notes)
+
+The full suite loads QtWebEngine and torch/faiss native libraries. Two hard-won
+rules keep runs from hanging or crashing:
+
+1. **Never capture the suite's stdout through a pipe.** QtWebEngine leaves a
+   native GPU/vsync thread (`QDxgiVSyncService`) alive at process exit. If a
+   parent reads the child's stdout via an OS pipe (`subprocess.run(...,
+   capture_output=True)` or a shell `|`), that leaked thread keeps the pipe's
+   write end open and the parent blocks **forever** on EOF — even though pytest
+   already finished. Redirect to a **file** instead (`stdout=<file>`), which has
+   no EOF-deadlock. Set `PYTHONUNBUFFERED=1` so output isn't lost when
+   `tests/conftest.py` calls `os._exit()` at session finish.
+2. **Always run with `pytest-timeout` armed** so a wedged test self-aborts with
+   a stack dump instead of hanging. The default `timeout = 120` /
+   `timeout_method = "thread"` lives in `[tool.pytest.ini_options]`.
+
+Preferred invocation (in-process runner, no shell — avoids PowerShell's stray
+`^U`/`&` control-character corruption that plagues long terminal runs):
+
+```python
+import subprocess, sys, os
+env = dict(os.environ); env["PYTHONUNBUFFERED"] = "1"
+with open("full_run.log", "w", encoding="utf-8") as fh:
+    rc = subprocess.run(
+        [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider",
+         "--timeout=120", "--timeout-method=thread"],
+        stdout=fh, stderr=subprocess.STDOUT, env=env, timeout=840,
+    ).returncode
+```
+
+Then read `full_run.log` for results. A clean run is **364 passed, 5 skipped**
+in ~4 min.
+
+`scripts/run_tests.py` is a process-isolated fallback (non-UI in one process,
+each UI test file in its own) for the rare WebEngine native-teardown crash on
+Windows, where `pytest --forked` is unavailable.
+
+**AI tests must never download the CLIP model.** `AiIndexerService` tests mock
+the model by patching the module globals
+`exif_turbo.indexing.ai_indexer_service._cached_model` /
+`_cached_preprocess`, or by setting `service._model` (honored by
+`_ensure_model_loaded`). A test that triggers the real ~605 MB download will
+fill the disk (each run writes to a fresh temp dir) and cause the very
+crashes/hangs above. If tests start hanging, **check free disk space first**.
+
 ## Conventions
 
 - Follow the standards defined in the `senior-python-engineer` agent for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,17 +8,17 @@ version = "1.14.14"
 description = "Fast EXIF full-text search with a PySide6 UI"
 requires-python = ">=3.11"
 dependencies = [
-  "PySide6>=6.5",
-  "Pillow>=10.0",
-  "rawpy>=0.18",
-  "av>=12.0",
-  "sqlcipher3>=0.5",
-  "markdown>=3.4",
-  "cryptography>=42.0",
-  "pyvips>=2.2",
-  "pyvips-binary>=2.2",
-  "faiss-cpu>=1.7",
-  "open-clip-torch>=2.24",
+  "PySide6>=6.11",
+  "Pillow>=12.3",
+  "rawpy>=0.27",
+  "av>=18.0",
+  "sqlcipher3>=0.6",
+  "markdown>=3.10",
+  "cryptography>=49.0",
+  "pyvips>=3.1",
+  "pyvips-binary>=8.18",
+  "faiss-cpu>=1.14",
+  "open-clip-torch>=3.3",
 ]
 
 [project.scripts]
@@ -32,7 +32,13 @@ where = ["src"]
 
 [project.optional-dependencies]
 build = ["pyinstaller", "babel"]
-dev = ["exif-turbo[build]", "pytest", "pytest-qt"]
+dev = ["exif-turbo[build]", "pytest", "pytest-qt", "pytest-timeout"]
 
 [tool.setuptools.package-data]
 exif_turbo = ["i18n/locales/**/*.mo", "i18n/locales/**/*.po"]
+
+[tool.pytest.ini_options]
+# Fail (with a stack dump) instead of hanging forever if a test wedges on a
+# leaked native thread (e.g. QtWebEngine GPU/vsync) or a blocked IPC recv.
+timeout = 120
+timeout_method = "thread"

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -1,0 +1,73 @@
+"""Process-isolated test runner for exif-turbo.
+
+The UI test suite initializes QtWebEngine and spawns background ``QThread``
+workers (``IndexWorker`` / ``ThumbWorker``) that touch SQLCipher/OpenSSL
+state.  When enough UI tests accumulate in a single interpreter, leaked
+native threads race process teardown and abort with SIGABRT (Windows exit
+codes 0xC0000005 / 0xC0000409) — an intermittent crash that is *not* a
+Python assertion failure.
+
+Windows has no ``fork``, so ``pytest --forked`` is unavailable.  Instead we
+isolate by process:
+
+* all non-UI tests run in one pytest process, and
+* each UI test *file* runs in its own pytest process.
+
+Every child inherits this process's stdout/stderr (no capture pipe), so a
+leaked native thread cannot deadlock a parent waiting for EOF, and per-test
+timeouts from ``pytest-timeout`` still apply.
+
+Usage::
+
+    python scripts/run_tests.py                # isolated run of the whole suite
+    python scripts/run_tests.py -k thumbnail   # extra args forwarded to pytest
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+UI_DIR = TESTS_DIR / "ui"
+
+
+def _run_pytest(targets: list[str], extra: list[str]) -> int:
+    """Run pytest as an isolated subprocess, inheriting this console."""
+    cmd = [sys.executable, "-m", "pytest", "-p", "no:cacheprovider", *targets, *extra]
+    print(f"\n=== pytest {' '.join(targets)} ===", flush=True)
+    completed = subprocess.run(cmd, cwd=REPO_ROOT)
+    return completed.returncode
+
+
+def main(argv: list[str]) -> int:
+    extra = argv[1:]
+
+    results: list[tuple[str, int]] = []
+
+    # 1) Everything except the UI tests, in a single clean process.
+    rc = _run_pytest(["tests", f"--ignore={UI_DIR.as_posix()}"], extra)
+    results.append(("non-ui", rc))
+
+    # 2) Each UI test file in its own process so native state can't accumulate.
+    ui_files = sorted(p for p in UI_DIR.glob("test_*.py"))
+    for ui_file in ui_files:
+        rel = ui_file.relative_to(REPO_ROOT).as_posix()
+        rc = _run_pytest([rel], extra)
+        results.append((rel, rc))
+
+    # Summary.
+    print("\n================ SUMMARY ================", flush=True)
+    failures = [(name, rc) for name, rc in results if rc != 0]
+    for name, rc in results:
+        status = "PASS" if rc == 0 else f"FAIL (rc={rc})"
+        print(f"  {status:<16} {name}", flush=True)
+    print(f"\n{len(results) - len(failures)}/{len(results)} groups passed", flush=True)
+
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/src/exif_turbo/indexing/ai_indexer_service.py
+++ b/src/exif_turbo/indexing/ai_indexer_service.py
@@ -141,6 +141,8 @@ class AiIndexerService:
 
     def _ensure_model_loaded(self) -> None:
         global _cached_model, _cached_preprocess
+        if self._model is not None:
+            return
         if _cached_model is not None:
             self._model = _cached_model
             self._preprocess = _cached_preprocess

--- a/tests/indexing/test_ai_indexer_service.py
+++ b/tests/indexing/test_ai_indexer_service.py
@@ -109,9 +109,13 @@ def test_ai_indexer_service_build_index_vectorises_images(
         np.stack([_fake_vec() for _ in image_files])
     ).float()
     fake_preprocess = MagicMock(return_value=torch.zeros(3, 224, 224))
-    fake_open_clip = MagicMock()
-    fake_open_clip.create_model_and_transforms.return_value = (
-        fake_model, MagicMock(), fake_preprocess
+    monkeypatch.setattr(
+        "exif_turbo.indexing.ai_indexer_service._cached_model",
+        fake_model,
+    )
+    monkeypatch.setattr(
+        "exif_turbo.indexing.ai_indexer_service._cached_preprocess",
+        fake_preprocess,
     )
 
     # Act

--- a/tests/utils/test_video_frame.py
+++ b/tests/utils/test_video_frame.py
@@ -41,6 +41,10 @@ def test_extract_video_frame_webm_sample_returns_thumbnail_sized_image() -> None
     # Act
     proc.start()
     child_conn.close()  # parent doesn't write
+    if not parent_conn.poll(60):
+        proc.terminate()
+        proc.join(timeout=10)
+        raise AssertionError("Child process produced no result within 60s (likely native crash)")
     result = parent_conn.recv()
     proc.join(timeout=60)
 


### PR DESCRIPTION
- Bump dependency floors to latest stable (PySide6, Pillow, rawpy, av, sqlcipher3, markdown, cryptography, pyvips, faiss-cpu, open-clip-torch).
- Add pytest-timeout with a 120s per-test cap so wedged tests self-abort instead of hanging indefinitely.
- Fix AI indexer tests that silently downloaded the ~605 MB CLIP model on every run (ineffective open_clip mock + reliance on test-ordering global cache), which filled the disk and caused intermittent native crashes/hangs.
- AiIndexerService._ensure_model_loaded now honors an already-set self._model.
- Guard the unbounded Pipe.recv() in test_video_frame against native child crash.
- Add scripts/run_tests.py: process-isolated runner (Windows has no fork).
- Document the reliable full-suite run method in copilot-instructions.