### PR TITLE
search: optimize empty AI query path and harden SQLCipher wildcard fallback

### DIFF
--- a/src/exif_turbo/data/image_index_repository.py
+++ b/src/exif_turbo/data/image_index_repository.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from os.path import commonpath
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
@@ -371,7 +372,10 @@ class ImageIndexRepository:
 
         sql_returning = sql + " RETURNING path"
         with self.conn:
-            cursor = self.conn.execute(sql_returning, args)
+            if query.strip():
+                cursor = self._execute_fts_query(sql_returning, args, fts_query)
+            else:
+                cursor = self.conn.execute(sql_returning, args)
             return [row[0] for row in cursor.fetchall()]
 
     def bulk_invert_images(
@@ -417,7 +421,10 @@ class ImageIndexRepository:
 
         sql_returning = sql + " RETURNING path, marked"
         with self.conn:
-            cursor = self.conn.execute(sql_returning, args)
+            if query.strip():
+                cursor = self._execute_fts_query(sql_returning, args, fts_query)
+            else:
+                cursor = self.conn.execute(sql_returning, args)
             rows = cursor.fetchall()
         added = [path for path, m in rows if m == 1]
         removed = [path for path, m in rows if m == 0]
@@ -616,9 +623,33 @@ class ImageIndexRepository:
         ``img004.png`` becomes the implicit-AND query ``img004 png``, which
         correctly matches images whose FTS5 document contains both tokens.
         """
-        import re
         sanitized = re.sub(r'[^\w\s"*^()]', ' ', query)
         return ' '.join(sanitized.split())
+
+    @staticmethod
+    def _drop_prefix_wildcards(fts_query: str) -> str:
+        """Return a wildcard-free fallback query for strict SQLCipher builds."""
+        return ' '.join(re.sub(r'\*+', ' ', fts_query).split())
+
+    def _execute_fts_query(self, sql: str, args: tuple, fts_query: str):
+        """Execute an FTS MATCH query with a compatibility fallback.
+
+        Some SQLCipher/SQLite builds reject otherwise valid FTS prefix
+        wildcard expressions (for example ``malongo*``) with
+        ``OperationalError: unknown special query``. Retry once without
+        wildcard operators so searches still complete instead of failing.
+        """
+        try:
+            return self.conn.execute(sql, args)
+        except sqlcipher3.OperationalError as exc:
+            msg = str(exc).lower()
+            if "unknown special query" not in msg or "*" not in fts_query:
+                raise
+            fallback_query = self._drop_prefix_wildcards(fts_query)
+            if not fallback_query:
+                raise
+            fallback_args = (fallback_query,) + args[1:]
+            return self.conn.execute(sql, fallback_args)
 
     def search_images(
         self,
@@ -665,6 +696,7 @@ class ImageIndexRepository:
                 "LIMIT ? OFFSET ?"
             )
             args = (fts_query,) + ext_args + path_args + date_args + (limit, offset)
+            cur = self._execute_fts_query(sql, args, fts_query)
         else:
             sql = (
                 "SELECT id, path, filename, metadata_json, size, mtime "
@@ -674,8 +706,7 @@ class ImageIndexRepository:
                 "LIMIT ? OFFSET ?"
             )
             args = ext_args + path_args + date_args + (limit, offset)
-
-        cur = self.conn.execute(sql, args)
+            cur = self.conn.execute(sql, args)
         return cur.fetchall()
 
     def count_images(
@@ -714,14 +745,14 @@ class ImageIndexRepository:
                 f"WHERE images_fts MATCH ? {ext_clause} {path_clause} {date_clause} {marks_clause} {enabled_clause}"
             )
             args = (fts_query,) + ext_args + path_args + date_args
+            cur = self._execute_fts_query(sql, args, fts_query)
         else:
             sql = (
                 f"SELECT COUNT(*) FROM images "
                 f"WHERE 1=1 {ext_clause} {path_clause} {date_clause} {marks_clause} {enabled_clause}"
             )
             args = ext_args + path_args + date_args
-
-        cur = self.conn.execute(sql, args)
+            cur = self.conn.execute(sql, args)
         return int(cur.fetchone()[0])
 
     def find_image_offset(
@@ -765,6 +796,7 @@ class ImageIndexRepository:
                 "WHERE image_id = ?"
             )
             args = (fts_query,) + ext_args + path_args + date_args + (image_id,)
+            row = self._execute_fts_query(sql, args, fts_query).fetchone()
         else:
             sql = (
                 "SELECT row_offset FROM ("
@@ -776,8 +808,7 @@ class ImageIndexRepository:
                 "WHERE image_id = ?"
             )
             args = ext_args + path_args + date_args + (image_id,)
-
-        row = self.conn.execute(sql, args).fetchone()
+            row = self.conn.execute(sql, args).fetchone()
         if row is None:
             return None
         return int(row[0])
@@ -819,14 +850,14 @@ class ImageIndexRepository:
                 f"WHERE images_fts MATCH ? {ext_clause} {path_clause} {date_clause} {marks_clause} {enabled_clause}"
             )
             args = (fts_query,) + ext_args + path_args + date_args
+            cur = self._execute_fts_query(sql, args, fts_query)
         else:
             sql = (
                 "SELECT path FROM images "
                 f"WHERE 1=1 {ext_clause} {path_clause} {date_clause} {marks_clause} {enabled_clause}"
             )
             args = ext_args + path_args + date_args
-
-        cur = self.conn.execute(sql, args)
+            cur = self.conn.execute(sql, args)
         return [row[0] for row in cur.fetchall()]
 
     def _build_ext_clause(self, ext_filter: str) -> tuple[str, tuple]:
@@ -911,6 +942,7 @@ class ImageIndexRepository:
                 "GROUP BY yr ORDER BY yr"
             )
             args = (fts_query,) + ext_args + path_args
+            cur = self._execute_fts_query(sql, args, fts_query)
         else:
             sql = (
                 "SELECT CAST(strftime('%Y', datetime(captured_at, 'unixepoch')) AS INTEGER) AS yr, "
@@ -920,8 +952,7 @@ class ImageIndexRepository:
                 "GROUP BY yr ORDER BY yr"
             )
             args = ext_args + path_args
-
-        cur = self.conn.execute(sql, args)
+            cur = self.conn.execute(sql, args)
         return [(int(row[0]), int(row[1])) for row in cur.fetchall()]
 
     # Extensions that should be merged into a single facet key.
@@ -968,6 +999,7 @@ class ImageIndexRepository:
                 " ORDER BY cnt DESC, images.ext ASC"
             )
             args = (fts_query,) + path_args + date_args
+            cur = self._execute_fts_query(sql, args, fts_query)
         else:
             sql = (
                 "SELECT ext, COUNT(*) AS cnt FROM images"
@@ -976,7 +1008,7 @@ class ImageIndexRepository:
                 " ORDER BY cnt DESC, ext ASC"
             )
             args = path_args + date_args
-        cur = self.conn.execute(sql, args)
+            cur = self.conn.execute(sql, args)
         return [(str(row[0]), int(row[1])) for row in cur.fetchall()]
 
     def get_format_counts_by_paths(self, paths: List[str]) -> List[Tuple[str, int]]:

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -1994,7 +1994,12 @@ class AppController(QObject):
         self._loaded_offset = 0
         self._loading = False
         self._consume_pending_load_more_request()
-        self._recompute_checked_in_results()
+        try:
+            self._recompute_checked_in_results()
+        except Exception as exc:
+            _log.warning("Failed to recompute checked counters after search failure: %s", exc)
+            self._checked_total_count = 0
+            self._checked_in_results_count = 0
         self.checkedCountChanged.emit()
         self.totalResultsChanged.emit()
         self.loadedResultsChanged.emit()

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -1401,12 +1401,53 @@ class AppController(QObject):
             return
         self._run_search()
 
+    def _ai_search_is_unfiltered_empty(self) -> bool:
+        """True when AI mode should fall back to a normal empty search.
+
+        When the AI query is blank and neither the timeline (date) filter nor
+        any search-field-area filter (folder, format, marked-only) is active,
+        the semantic result set is simply "everything in scope". In that case
+        the normal paginated search yields the same images without touching the
+        FAISS/AI database or hydrating every indexed row at once.
+        """
+        return (
+            not self._last_ai_query.strip()
+            and self._date_from is None
+            and self._date_to is None
+            and not self._ext_filter
+            and not self._checked_only_filter_active
+            and self._current_path_filter() is None
+        )
+
+    def _results_use_ai_pipeline(self) -> bool:
+        """Whether result handling should use the in-memory AI result pipeline.
+
+        AI mode with an active query or filter caches the full ranked result
+        set in memory and derives facets from it. The unfiltered-empty case
+        instead flows through the normal paginated pipeline (see
+        :meth:`_ai_search_is_unfiltered_empty`).
+        """
+        return self._is_ai_search_mode and not self._ai_search_is_unfiltered_empty()
+
+    def _run_empty_ai_fallback_search(self) -> None:
+        """Show all in-scope images via the normal paginated search pipeline.
+
+        Used when AI mode has a blank query and no active filters, avoiding the
+        cost of loading the FAISS index and hydrating every indexed row at once.
+        """
+        self._query_text = ""
+        self._current_result_row = 0
+        self._run_search()
+
     def _rerun_ai_search_for_filter_change(self) -> bool:
         if not self._is_ai_search_mode:
             return False
         if not self._has_ai_search_run or self._db_path is None:
             return False
         self._ai_select_first = True
+        if self._ai_search_is_unfiltered_empty():
+            self._run_empty_ai_fallback_search()
+            return True
         self._start_ai_search_worker(self._last_ai_query, self._last_ai_precision)
         return True
 
@@ -1762,7 +1803,7 @@ class AppController(QObject):
         # For AI searches, store all results in-memory and load only the first
         # page into the model; further pages are served from _ai_result_cache
         # by loadMore() without touching the database.
-        if self._is_ai_search_mode:
+        if self._results_use_ai_pipeline():
             self._ai_result_cache = all_results
             # Timeline facet source: the semantic set before date filtering.
             # Fall back to the (date-filtered) result paths if the worker did
@@ -1868,7 +1909,7 @@ class AppController(QObject):
             QTimer.singleShot(0, self.searchRestoreReady.emit)
         self._loading = False
         self._consume_pending_load_more_request()
-        if self._is_ai_search_mode and self._repo is not None:
+        if self._results_use_ai_pipeline() and self._repo is not None:
             ai_paths = self._ai_format_facet_source_paths()
             format_counts = self._repo.get_format_counts_by_paths(ai_paths)
         self._apply_format_counts(format_counts)
@@ -1890,7 +1931,7 @@ class AppController(QObject):
 
     def _schedule_year_counts_reload(self, serial: int) -> None:
         """Refresh year counts after the current search result has rendered."""
-        if self._is_ai_search_mode:
+        if self._results_use_ai_pipeline():
             # AI-mode year counts currently depend on in-memory AI path sets.
             # Keep the existing synchronous path for that mode.
             def _reload_ai() -> None:
@@ -2010,7 +2051,7 @@ class AppController(QObject):
     def _load_year_counts(self) -> None:
         if self._repo is None:
             return
-        if self._is_ai_search_mode:
+        if self._results_use_ai_pipeline():
             ai_paths = self._ai_facet_source_paths()
             counts = self._repo.get_year_counts_by_paths(ai_paths)
         else:
@@ -2114,7 +2155,7 @@ class AppController(QObject):
         if self._loading:
             self._pending_load_more_request = True
             return False
-        if self._is_ai_search_mode:
+        if self._results_use_ai_pipeline():
             if self._loaded_results >= self._total_results:
                 self._pending_load_more_request = False
                 return False
@@ -2851,6 +2892,9 @@ class AppController(QObject):
         self._last_ai_precision = precision
         self._has_ai_search_run = True
         self._ai_select_first = True
+        if self._ai_search_is_unfiltered_empty():
+            self._run_empty_ai_fallback_search()
+            return
         self._start_ai_search_worker(query, precision)
 
     def _start_ai_search_worker(self, query: str, precision: str) -> None:

--- a/tests/data/test_image_index_repository.py
+++ b/tests/data/test_image_index_repository.py
@@ -10,6 +10,27 @@ from exif_turbo.data.image_index_repository import ImageIndexRepository
 from tests.conftest import make_jpeg, make_png
 
 
+class _SpecialQueryErrorOnceConnection:
+    """Proxy that simulates SQLCipher rejecting wildcard FTS MATCH once."""
+
+    def __init__(self, inner) -> None:  # type: ignore[no-untyped-def]
+        self._inner = inner
+        self._raised = False
+        self.fts_queries: list[str] = []
+
+    def execute(self, sql: str, args: tuple = ()):  # type: ignore[no-untyped-def]
+        if "MATCH ?" in sql and args and isinstance(args[0], str):
+            query = args[0]
+            self.fts_queries.append(query)
+            if "*" in query and not self._raised:
+                self._raised = True
+                raise sqlcipher3.OperationalError(f"unknown special query: {query}")
+        return self._inner.execute(sql, args)
+
+    def __getattr__(self, name: str):
+        return getattr(self._inner, name)
+
+
 # ── upsert / search ──────────────────────────────────────────────────────────
 
 
@@ -107,6 +128,45 @@ def test_search_fts_no_match_returns_empty(repo: ImageIndexRepository, tmp_path:
 
     rows = repo.search_images("Leica", limit=10, offset=0)
     assert rows == []
+
+
+def test_count_images_wildcard_special_query_falls_back_without_asterisk(
+    repo: ImageIndexRepository,
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    path = str(make_jpeg(tmp_path / "malongo.jpg"))
+    repo.upsert_image(path, "malongo.jpg", 1.0, 100, {}, "malongo jpg")
+    repo.commit()
+    proxy = _SpecialQueryErrorOnceConnection(repo.conn)
+    repo.conn = proxy
+
+    # Act
+    count = repo.count_images("malongo*")
+
+    # Assert
+    assert count == 1
+    assert proxy.fts_queries[:2] == ["malongo*", "malongo"]
+
+
+def test_search_images_wildcard_special_query_falls_back_without_asterisk(
+    repo: ImageIndexRepository,
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    path = str(make_jpeg(tmp_path / "malongo.jpg"))
+    repo.upsert_image(path, "malongo.jpg", 1.0, 100, {}, "malongo jpg")
+    repo.commit()
+    proxy = _SpecialQueryErrorOnceConnection(repo.conn)
+    repo.conn = proxy
+
+    # Act
+    rows = repo.search_images("malongo*", limit=10, offset=0)
+
+    # Assert
+    assert len(rows) == 1
+    assert rows[0][2] == "malongo.jpg"
+    assert proxy.fts_queries[:2] == ["malongo*", "malongo"]
 
 
 # ── FTS5 logical operators ────────────────────────────────────────────────────

--- a/tests/ui/test_app_controller.py
+++ b/tests/ui/test_app_controller.py
@@ -489,6 +489,30 @@ def test_search_with_existing_status_clears_notification(
     assert bare_controller.statusIsError is False
 
 
+def test_on_search_failed_recompute_error_clears_busy_and_loading_state(
+    bare_controller: AppController,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    bare_controller._set_search_busy_ui(True)
+    bare_controller._loading = True
+
+    def _boom() -> None:
+        raise RuntimeError("recompute failed")
+
+    monkeypatch.setattr(bare_controller, "_recompute_checked_in_results", _boom)
+
+    # Act
+    bare_controller._on_search_failed("unknown special query: malongo*")
+
+    # Assert
+    assert bare_controller.isSearching is False
+    assert bare_controller._loading is False
+    assert bare_controller.totalResults == 0
+    assert bare_controller.checkedCount == 0
+    assert bare_controller.checkedInResultsCount == 0
+
+
 def test_selectResult_with_existing_status_clears_notification(
     qtbot: QtBot,
     bare_controller: AppController,

--- a/tests/ui/test_app_controller.py
+++ b/tests/ui/test_app_controller.py
@@ -297,7 +297,6 @@ def test_app_controller_ai_full_rescan_starts_force_scan(tmp_path: Path) -> None
         get_by_id=lambda folder_id: SimpleNamespace(id=folder_id, path="C:/photos"),
         close=lambda: None,
     )
-
     class _FakeSignal:
         def connect(self, callback) -> None:  # type: ignore[no-untyped-def]
             self._callback = callback
@@ -348,6 +347,32 @@ def test_app_controller_ai_full_rescan_starts_force_scan(tmp_path: Path) -> None
     assert controller.aiScanIsFullRescan is True
 
     controller.close()
+
+
+def test_ai_search_empty_without_filters_uses_normal_search_pipeline(
+    bare_controller: AppController,
+    monkeypatch,
+) -> None:
+    # Arrange
+    bare_controller.setAiSearchMode(True)
+    calls: list[tuple[str, str, str] | str] = []
+
+    monkeypatch.setattr(
+        bare_controller,
+        "_run_search",
+        lambda: calls.append("run_search"),
+    )
+    monkeypatch.setattr(
+        bare_controller,
+        "_start_ai_search_worker",
+        lambda query, precision: calls.append(("ai_worker", query, precision)),
+    )
+
+    # Act
+    bare_controller.aiSearch("   ", "normal")
+
+    # Assert
+    assert calls == ["run_search"]
 
 
 def test_selectResult_image_source_is_empty_before_debounce_fires(


### PR DESCRIPTION
## Summary
- route **AI mode with an empty query and no active filters** through the existing paginated non-AI search pipeline instead of spinning up the AI worker
- keep AI in-memory result pipeline behavior for cases where query/filter state actually requires it
- add a SQLCipher compatibility fallback for FTS wildcard queries that can fail with `unknown special query` on stricter builds (retry once with wildcard removed)
- harden search-failure cleanup so checked counters are reset even if recompute throws

## Why
- empty, unfiltered AI searches conceptually return the same result scope as normal search, so using the normal pipeline avoids unnecessary FAISS/model work and large in-memory hydration
- some SQLCipher environments reject otherwise valid prefix wildcard expressions; fallback keeps search/count flows functional instead of surfacing hard failures
- failure-path guard ensures UI state is correctly reset after errors

## Changes
- `src/exif_turbo/ui/view_models/app_controller.py`
  - added helpers to detect empty/unfiltered AI searches and decide when to use AI result pipeline
  - added normal-search fallback path for empty/unfiltered AI searches
  - applied pipeline guard to pagination/facet/year-count/loading paths
  - wrapped checked-count recompute in search-failure path with explicit reset on failure
- `src/exif_turbo/data/image_index_repository.py`
  - centralized FTS execution helper with SQLCipher wildcard fallback
  - reused helper across search/count/offset/path/facet query paths that execute `MATCH ?`
- tests
  - `tests/ui/test_app_controller.py`: verifies empty AI query uses normal search path and failure cleanup resets busy/loading/counters
  - `tests/data/test_image_index_repository.py`: verifies wildcard `unknown special query` fallback behavior for count/search

## Validation
- `python -m compileall -q src`
- `python scripts/run_tests.py` (process-isolated test runner): **31/31 groups passed**