### PR TITLE
fix(release): route version_info.py through the release PR

### DIFF
--- a/exif-turbo.spec
+++ b/exif-turbo.spec
@@ -2,9 +2,14 @@
 # Windows PyInstaller spec — produces a onedir bundle with the GUI.
 # Run via: scripts\build_windows.ps1
 import re
+import sys
 from pathlib import Path
 
 from PyInstaller.utils.hooks import collect_data_files
+
+# Make the shared version_info generator importable (cwd is the repo root).
+sys.path.insert(0, str(Path('scripts').resolve()))
+from gen_version_info import write_version_info  # noqa: E402
 
 # Read version from the single source of truth
 _version_match = re.search(
@@ -13,48 +18,9 @@ _version_match = re.search(
     re.MULTILINE,
 )
 VERSION = _version_match.group(1) if _version_match else '0.0.0'
-_major, _minor, _patch = (VERSION.split('.') + ['0', '0', '0'])[:3]
-VERSION_TUPLE = (int(_major), int(_minor), int(_patch), 0)
 
 # Generate version_info.py for Windows exe metadata
-Path('version_info.py').write_text(
-    f'''\
-# Auto-generated from exif-turbo.spec — do not edit manually.
-VSVersionInfo(
-    ffi=FixedFileInfo(
-        filevers={VERSION_TUPLE},
-        prodvers={VERSION_TUPLE},
-        mask=0x3F,
-        flags=0x0,
-        OS=0x40004,
-        fileType=0x1,
-        subtype=0x0,
-        date=(0, 0),
-    ),
-    kids=[
-        StringFileInfo(
-            [
-                StringTable(
-                    "040904B0",
-                    [
-                        StringStruct("CompanyName", "exif-turbo"),
-                        StringStruct("FileDescription", "exif-turbo — Image EXIF metadata search and indexing tool"),
-                        StringStruct("FileVersion", "{VERSION}"),
-                        StringStruct("InternalName", "exif-turbo"),
-                        StringStruct("LegalCopyright", "Copyright (c) 2025 exif-turbo contributors"),
-                        StringStruct("OriginalFilename", "exif-turbo.exe"),
-                        StringStruct("ProductName", "exif-turbo"),
-                        StringStruct("ProductVersion", "{VERSION}"),
-                    ],
-                )
-            ]
-        ),
-        VarFileInfo([VarStruct("Translation", [1033, 1200])]),
-    ],
-)
-''',
-    encoding='utf-8',
-)
+write_version_info(VERSION, Path('version_info.py'))
 
 _icon_path = Path('assets\\icon.ico')
 _icon_args = [str(_icon_path)] if _icon_path.exists() else []

--- a/scripts/build_windows.py
+++ b/scripts/build_windows.py
@@ -79,20 +79,6 @@ def compile_translations() -> None:
     print("  Translation catalogs compiled.")
 
 
-def commit_version_info(version: str) -> None:
-    """Stage and commit auto-generated version_info.py if it changed."""
-    status = subprocess.run(
-        ["git", "status", "--short", "version_info.py"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-    )
-    if status.stdout.strip():
-        run(["git", "add", "version_info.py"])
-        run(["git", "commit", "-m", f"chore: update version_info.py to {version}"])
-        print(f"  Committed version_info.py ({version}).")
-
-
 def stage_exiftool() -> Path:
     """Download and stage the ExifTool 64-bit Windows binary for the MSI.
 
@@ -192,8 +178,6 @@ def main() -> None:
 
     run([pyinstaller, "exif-turbo.spec", "--noconfirm", "--clean"])
     print("  PyInstaller build complete.")
-
-    commit_version_info(version)
 
     app_dir = (REPO_ROOT / "dist" / "exif-turbo").resolve()
     msi_out = REPO_ROOT / "dist" / f"exif-turbo-{version}-windows.msi"

--- a/scripts/gen_version_info.py
+++ b/scripts/gen_version_info.py
@@ -1,0 +1,57 @@
+"""Shared generator for the Windows ``version_info.py`` exe-metadata file.
+
+``version_info.py`` is derived solely from the project version string. It is
+consumed by PyInstaller (via ``exif-turbo.spec``) to stamp the Windows EXE
+resource metadata. Keeping the template here lets both the PyInstaller spec and
+the release tooling produce byte-identical output from a single source.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def render_version_info(version: str) -> str:
+    """Return the ``version_info.py`` contents for a given semantic version."""
+    major, minor, patch = (version.split(".") + ["0", "0", "0"])[:3]
+    version_tuple = (int(major), int(minor), int(patch), 0)
+    return f'''\
+# Auto-generated from exif-turbo.spec — do not edit manually.
+VSVersionInfo(
+    ffi=FixedFileInfo(
+        filevers={version_tuple},
+        prodvers={version_tuple},
+        mask=0x3F,
+        flags=0x0,
+        OS=0x40004,
+        fileType=0x1,
+        subtype=0x0,
+        date=(0, 0),
+    ),
+    kids=[
+        StringFileInfo(
+            [
+                StringTable(
+                    "040904B0",
+                    [
+                        StringStruct("CompanyName", "exif-turbo"),
+                        StringStruct("FileDescription", "exif-turbo — Image EXIF metadata search and indexing tool"),
+                        StringStruct("FileVersion", "{version}"),
+                        StringStruct("InternalName", "exif-turbo"),
+                        StringStruct("LegalCopyright", "Copyright (c) 2025 exif-turbo contributors"),
+                        StringStruct("OriginalFilename", "exif-turbo.exe"),
+                        StringStruct("ProductName", "exif-turbo"),
+                        StringStruct("ProductVersion", "{version}"),
+                    ],
+                )
+            ]
+        ),
+        VarFileInfo([VarStruct("Translation", [1033, 1200])]),
+    ],
+)
+'''
+
+
+def write_version_info(version: str, path: Path) -> None:
+    """Write ``version_info.py`` for ``version`` to ``path`` (UTF-8)."""
+    path.write_text(render_version_info(version), encoding="utf-8")

--- a/scripts/release_windows.py
+++ b/scripts/release_windows.py
@@ -4,7 +4,8 @@ Given either ``major minor patch``, ``x.y.z``, or a bump keyword
 (``patch``, ``minor``, ``major``) this script will:
 
 Prepare-PR stage (default):
-1. Bump version in ``src/exif_turbo/__init__.py`` and ``pyproject.toml``.
+1. Bump version in ``src/exif_turbo/__init__.py``, ``pyproject.toml`` and
+   the Windows exe-metadata file ``version_info.py``.
 2. Commit the version bump on the current branch.
 3. Push the branch and create (or reuse) a PR to ``main``.
 
@@ -35,10 +36,14 @@ import sys
 import zipfile
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from gen_version_info import write_version_info  # noqa: E402
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 INIT_FILE = REPO_ROOT / "src" / "exif_turbo" / "__init__.py"
 PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
+VERSION_INFO_FILE = REPO_ROOT / "version_info.py"
 
 
 class ShellError(RuntimeError):
@@ -153,9 +158,13 @@ def write_version(version: str) -> None:
         raise ShellError(f"Failed to update version in {PYPROJECT_FILE}")
     PYPROJECT_FILE.write_text(pyproject_new, encoding="utf-8")
 
+    # Regenerate the Windows exe-metadata file so it lands in the release PR
+    # instead of being committed directly to a protected 'main' at build time.
+    write_version_info(version, VERSION_INFO_FILE)
+
 
 def commit_version_bump(version: str) -> None:
-    run(["git", "add", str(INIT_FILE), str(PYPROJECT_FILE)])
+    run(["git", "add", str(INIT_FILE), str(PYPROJECT_FILE), str(VERSION_INFO_FILE)])
     run(["git", "commit", "-m", f"chore: bump version to {version}"])
 
 

--- a/version_info.py
+++ b/version_info.py
@@ -1,8 +1,8 @@
 # Auto-generated from exif-turbo.spec — do not edit manually.
 VSVersionInfo(
     ffi=FixedFileInfo(
-        filevers=(1, 14, 14, 0),
-        prodvers=(1, 14, 14, 0),
+        filevers=(1, 14, 15, 0),
+        prodvers=(1, 14, 15, 0),
         mask=0x3F,
         flags=0x0,
         OS=0x40004,
@@ -18,12 +18,12 @@ VSVersionInfo(
                     [
                         StringStruct("CompanyName", "exif-turbo"),
                         StringStruct("FileDescription", "exif-turbo — Image EXIF metadata search and indexing tool"),
-                        StringStruct("FileVersion", "1.14.14"),
+                        StringStruct("FileVersion", "1.14.15"),
                         StringStruct("InternalName", "exif-turbo"),
                         StringStruct("LegalCopyright", "Copyright (c) 2025 exif-turbo contributors"),
                         StringStruct("OriginalFilename", "exif-turbo.exe"),
                         StringStruct("ProductName", "exif-turbo"),
-                        StringStruct("ProductVersion", "1.14.14"),
+                        StringStruct("ProductVersion", "1.14.15"),
                     ],
                 )
             ]


### PR DESCRIPTION
## Problem

The Windows release `publish` stage runs on `main`. During the build,
`scripts/build_windows.py` called `commit_version_info()`, which committed
the auto-generated `version_info.py` **directly onto `main`**. Because
`main` is protected and cannot be pushed to directly, that commit was left
stranded locally with nowhere to go.

## Fix

- Generate `version_info.py` during the **prepare-pr** stage
  (`scripts/release_windows.py`) so it is committed alongside the version
  bump and flows to `main` through the release PR.
- Remove the direct `git commit` of `version_info.py` from
  `scripts/build_windows.py`.
- Extract the `version_info.py` template into `scripts/gen_version_info.py`
  so the PyInstaller spec and the release script share a single source of
  truth (verified byte-identical output).

## Contents

This PR also carries the pending `version_info.py` bump to `1.14.15`.