### PR TITLE
Fix macOS release builds with Python 3.14 and PySide6 6.11

### DIFF
--- a/scripts/build_macos.py
+++ b/scripts/build_macos.py
@@ -244,7 +244,8 @@ def main() -> None:
     generate_icns()
     compile_translations()
 
-    run(["pyinstaller", "--noconfirm", "--clean", spec_file])
+    pyinstaller = find_tool("pyinstaller", venv_subpath=".venv/bin/pyinstaller")
+    run([pyinstaller, "--noconfirm", "--clean", spec_file])
     print("  PyInstaller build complete.")
 
     app = REPO_ROOT / "dist" / "exif-turbo.app"

--- a/scripts/stage_runtime_licenses.py
+++ b/scripts/stage_runtime_licenses.py
@@ -19,6 +19,12 @@ from packaging.utils import canonicalize_name
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_OUTPUT_DIR = REPO_ROOT / "build" / "license-staged"
 _LICENSE_PREFIXES = ("LICENSE", "COPYING", "NOTICE")
+_QT_DISTRIBUTIONS = {
+    "pyside6",
+    "pyside6-addons",
+    "pyside6-essentials",
+    "shiboken6",
+}
 _QT_LICENSES = {
     "GPL-2.0-only.txt": ("GNU GENERAL PUBLIC LICENSE", 17_000, "END OF TERMS AND CONDITIONS"),
     "GPL-3.0-only.txt": ("GNU GENERAL PUBLIC LICENSE", 34_000, "END OF TERMS AND CONDITIONS"),
@@ -37,7 +43,8 @@ _LIBVIPS_FILES = {
         "END OF TERMS AND CONDITIONS",
     ),
     "LGPL-3.0-only.txt": (
-        "https://www.gnu.org/licenses/lgpl-3.0.txt",
+        "https://raw.githubusercontent.com/spdx/license-list-data/"
+        "main/text/LGPL-3.0-only.txt",
         "GNU LESSER GENERAL PUBLIC LICENSE",
         7_000,
         "permanent authorization for you to choose that version",
@@ -149,7 +156,20 @@ def _safe_filename(path: Path, used: set[str]) -> str:
 
 def _python_license_file() -> Path:
     installed_base = Path(str(sysconfig.get_config_var("installed_base")))
-    for candidate in (installed_base / "LICENSE.txt", installed_base / "LICENSE"):
+    candidates = [installed_base / "LICENSE.txt", installed_base / "LICENSE"]
+    framework_dir = next(
+        (parent for parent in installed_base.parents if parent.name == "Python.framework"),
+        None,
+    )
+    if framework_dir is not None:
+        candidates.extend(
+            (
+                framework_dir / "Resources" / "English.lproj" / "License.rtf",
+                framework_dir.parent.parent / "LICENSE.txt",
+                framework_dir.parent.parent / "LICENSE",
+            )
+        )
+    for candidate in candidates:
         if candidate.is_file():
             return candidate
     raise LicenseStagingError(
@@ -293,7 +313,9 @@ def stage_runtime_licenses(
     package_licenses: list[tuple[Distribution, tuple[Path, ...]]] = []
     for package in packages:
         files = _license_files(package)
-        if not files:
+        if not files and canonicalize_name(package.metadata["Name"]) not in (
+            _QT_DISTRIBUTIONS
+        ):
             raise LicenseStagingError(
                 "runtime distribution has no packaged license file: "
                 f"{package.metadata['Name']} {package.version}"
@@ -317,17 +339,20 @@ def stage_runtime_licenses(
             "",
             "Generated from the active build environment. Each directory below",
             "contains the unmodified license/notice files shipped by that distribution.",
+            "Qt for Python wheels that omit these files reference validated upstream",
+            "Qt license texts in the shared qt/<version> directory.",
             "",
         ]
         python_dir = staged / "python"
         for package, license_files in package_licenses:
             name = package.metadata["Name"]
             version = package.version
-            package_dir = python_dir / f"{canonicalize_name(name)}-{version}"
-            package_dir.mkdir(parents=True)
+            canonical_name = canonicalize_name(name)
+            package_dir = python_dir / f"{canonical_name}-{version}"
             used_names: set[str] = set()
             copied_names: list[str] = []
             for source in license_files:
+                package_dir.mkdir(parents=True, exist_ok=True)
                 filename = _safe_filename(source, used_names)
                 shutil.copy2(source, package_dir / filename)
                 copied_names.append(filename)
@@ -341,15 +366,23 @@ def stage_runtime_licenses(
             manifest.extend(
                 f"  python/{package_dir.name}/{item}" for item in copied_names
             )
+
+            if canonical_name in _QT_DISTRIBUTIONS:
+                qt_dir = staged / "qt" / version
+                if not qt_dir.exists():
+                    qt_dir.mkdir(parents=True)
+                    for source in _qt_license_files(version):
+                        shutil.copy2(source, qt_dir / source.name)
+                if not license_files:
+                    manifest.extend(
+                        f"  qt/{version}/{source.name}"
+                        for source in sorted(qt_dir.iterdir())
+                        if source.is_file()
+                    )
+
             manifest.append("")
 
-            if canonicalize_name(name) == "pyside6":
-                qt_dir = staged / "qt" / version
-                qt_dir.mkdir(parents=True)
-                for source in _qt_license_files(version):
-                    shutil.copy2(source, qt_dir / source.name)
-
-            if canonicalize_name(name) == "pyvips-binary":
+            if canonical_name == "pyvips-binary":
                 libvips_dir = staged / "libvips" / version
                 libvips_dir.mkdir(parents=True)
                 for source in _libvips_license_files(version):

--- a/tests/scripts/test_stage_runtime_licenses.py
+++ b/tests/scripts/test_stage_runtime_licenses.py
@@ -56,6 +56,30 @@ def _write_project_notices(project_root: Path) -> None:
     )
 
 
+def test_python_license_file_homebrew_framework_returns_formula_license(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    formula_root = tmp_path / "python@3.14"
+    installed_base = (
+        formula_root / "Frameworks" / "Python.framework" / "Versions" / "3.14"
+    )
+    installed_base.mkdir(parents=True)
+    license_file = formula_root / "LICENSE"
+    license_file.write_text("Python terms", encoding="utf-8")
+    monkeypatch.setattr(
+        stage_runtime_licenses.sysconfig,
+        "get_config_var",
+        lambda _name: str(installed_base),
+    )
+
+    # Act
+    result = stage_runtime_licenses._python_license_file()
+
+    # Assert
+    assert result == license_file
+
+
 def test_runtime_distributions_transitive_and_inactive_marker_resolves_active_closure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -173,6 +197,60 @@ def test_stage_runtime_licenses_package_without_license_raises_error(
     assert (output_dir / "STAGING-COMPLETE").read_text(encoding="ascii") == (
         "previous\n"
     )
+
+
+def test_stage_runtime_licenses_qt_wheels_without_licenses_use_upstream_texts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_project_notices(project_root)
+    packages = {
+        "PySide6": FakeDistribution(
+            tmp_path,
+            "PySide6",
+            "6.11.1",
+            requires=("PySide6-Essentials", "PySide6-Addons", "shiboken6"),
+        ),
+        "PySide6-Essentials": FakeDistribution(
+            tmp_path, "PySide6-Essentials", "6.11.1"
+        ),
+        "PySide6-Addons": FakeDistribution(tmp_path, "PySide6-Addons", "6.11.1"),
+        "shiboken6": FakeDistribution(tmp_path, "shiboken6", "6.11.1"),
+    }
+    python_license = tmp_path / "PYTHON-LICENSE.txt"
+    python_license.write_text("Python terms", encoding="utf-8")
+    qt_license = tmp_path / "LGPL-3.0-only.txt"
+    qt_license.write_text("Qt terms", encoding="utf-8")
+    monkeypatch.setattr(stage_runtime_licenses, "REPO_ROOT", project_root)
+    monkeypatch.setattr(
+        stage_runtime_licenses, "_python_license_file", lambda: python_license
+    )
+    monkeypatch.setattr(
+        stage_runtime_licenses, "_qt_license_files", lambda _version: (qt_license,)
+    )
+    monkeypatch.setattr(
+        stage_runtime_licenses,
+        "distribution",
+        lambda name: _as_distribution(packages[name]),
+    )
+    output_dir = tmp_path / "staged"
+
+    # Act
+    stage_runtime_licenses.stage_runtime_licenses(
+        output_dir, requirements=("PySide6",)
+    )
+
+    # Assert
+    assert (output_dir / "qt" / "6.11.1" / "LGPL-3.0-only.txt").read_text(
+        encoding="utf-8"
+    ) == "Qt terms"
+    manifest = (output_dir / "PYTHON-RUNTIME-LICENSES.txt").read_text(
+        encoding="utf-8"
+    )
+    assert all(f"{name} 6.11.1" in manifest for name in packages)
+    assert "qt/6.11.1/LGPL-3.0-only.txt" in manifest
 
 
 def test_stage_runtime_licenses_pyvips_binary_adds_native_compliance_files(


### PR DESCRIPTION
## Summary

- use validated upstream Qt license texts when PySide6 6.11 wheels omit packaged license files
- locate the CPython license in Homebrew macOS framework installations and use SPDX as the LGPL fallback source
- resolve PyInstaller from the project virtual environment without requiring shell activation

## Validation

- `python -m pytest -q tests/scripts/test_stage_runtime_licenses.py tests/scripts/test_audit_release_artifact.py` (12 passed)
- `python scripts/stage_runtime_licenses.py` (52 runtime distributions staged)
- `python scripts/update_macos_release.py` (ARM64 app built, audited, signed, packaged, and uploaded)