### PR TITLE
fix: correct derivative video tagging

### DIFF
--- a/src/exif_turbo/tagging/derivative_export_service.py
+++ b/src/exif_turbo/tagging/derivative_export_service.py
@@ -14,6 +14,7 @@ from typing import Callable, Iterable, Mapping, Protocol, Sequence
 
 from ..data.image_index_repository import ImageIndexRepository
 from .exif_metadata_writer import ExifMetadataWriter
+from .sidecar_repository import FilesystemSidecarRepository
 
 
 _EMBEDDED_KEYWORD_KEYS = (
@@ -141,9 +142,11 @@ class DerivativeExportService:
         self,
         image_repository: ImageIndexRepository,
         metadata_writer: MetadataWriter | None = None,
+        sidecar_repository: FilesystemSidecarRepository | None = None,
     ) -> None:
         self._image_repository = image_repository
         self._metadata_writer = metadata_writer or ExifMetadataWriter()
+        self._sidecar_repository = sidecar_repository or FilesystemSidecarRepository()
 
     def create_plan(
         self,
@@ -299,14 +302,17 @@ class DerivativeExportService:
                 pass
 
     def _accepted_labels(self, source: Path) -> tuple[str, ...]:
+        loaded_sidecar = self._sidecar_repository.read(source)
+        if loaded_sidecar is None:
+            return ()
         accepted_labels = [
             tag.label.strip()
-            for tag in self._image_repository.get_accepted_tags(str(source))
+            for tag in loaded_sidecar.sidecar.tags
             if tag.label.strip()
         ]
         accepted_labels.extend(
             label.strip()
-            for label in self._image_repository.get_free_tags(str(source))
+            for label in loaded_sidecar.sidecar.free_tags
             if label.strip()
         )
         if not accepted_labels:

--- a/src/exif_turbo/tagging/exif_metadata_writer.py
+++ b/src/exif_turbo/tagging/exif_metadata_writer.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 
 from ..indexing.exif_metadata_extractor import find_exiftool
+from ..indexing.image_utils import VIDEO_EXTENSIONS
 
 
 class ExifMetadataWriteError(RuntimeError):
@@ -31,15 +32,15 @@ class ExifMetadataWriter:
                 f"refusing to write metadata to source image: {target}"
             )
 
-        labels = self._merge_labels(labels, self._read_keywords(target))
+        fields = self._keyword_fields(target)
+        labels = self._merge_labels(labels, self._read_keywords(target, fields))
         clear_arguments = [
             find_exiftool(),
             "-m",
             "-overwrite_original",
-            "-XMP-dc:Subject=",
-            "-IPTC:Keywords=",
-            str(target),
         ]
+        clear_arguments.extend(f"-{field}=" for field in fields)
+        clear_arguments.append(str(target))
         clear_result = self._run(clear_arguments)
         if clear_result.returncode != 0:
             detail = (
@@ -51,24 +52,23 @@ class ExifMetadataWriter:
 
         arguments = [find_exiftool(), "-m", "-overwrite_original"]
         for label in labels:
-            arguments.extend(
-                (f"-XMP-dc:Subject+={label}", f"-IPTC:Keywords+={label}")
-            )
+            arguments.extend(f"-{field}+={label}" for field in fields)
         arguments.append(str(target))
         result = self._run(arguments)
         if result.returncode != 0:
             detail = result.stderr.strip() or result.stdout.strip() or "unknown error"
             raise ExifMetadataWriteError(f"ExifTool metadata write failed: {detail}")
-        self._verify_keywords(target, labels)
+        self._verify_keywords(target, labels, fields)
 
-    def _read_keywords(self, target: Path) -> tuple[str, ...]:
+    def _read_keywords(
+        self, target: Path, fields: tuple[str, ...]
+    ) -> tuple[str, ...]:
         result = self._run(
             [
                 find_exiftool(),
                 "-json",
                 "-G1",
-                "-XMP-dc:Subject",
-                "-IPTC:Keywords",
+                *(f"-{field}" for field in fields),
                 str(target),
             ]
         )
@@ -78,22 +78,22 @@ class ExifMetadataWriter:
         try:
             record = json.loads(result.stdout)[0]
             return self._merge_labels(
-                self._as_labels(record.get("XMP-dc:Subject")),
-                self._as_labels(record.get("IPTC:Keywords")),
+                *(self._as_labels(record.get(field)) for field in fields)
             )
         except (IndexError, TypeError, ValueError, json.JSONDecodeError) as exc:
             raise ExifMetadataWriteError(
                 "ExifTool returned invalid metadata"
             ) from exc
 
-    def _verify_keywords(self, target: Path, labels: Sequence[str]) -> None:
+    def _verify_keywords(
+        self, target: Path, labels: Sequence[str], fields: tuple[str, ...]
+    ) -> None:
         result = self._run(
             [
                 find_exiftool(),
                 "-json",
                 "-G1",
-                "-XMP-dc:Subject",
-                "-IPTC:Keywords",
+                *(f"-{field}" for field in fields),
                 str(target),
             ]
         )
@@ -103,17 +103,22 @@ class ExifMetadataWriter:
         try:
             records = json.loads(result.stdout)
             record = records[0]
-            subject = self._as_labels(record.get("XMP-dc:Subject"))
-            keywords = self._as_labels(record.get("IPTC:Keywords"))
+            actual = tuple(self._as_labels(record.get(field)) for field in fields)
         except (IndexError, KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
             raise ExifMetadataWriteError(
                 "ExifTool returned invalid metadata readback"
             ) from exc
         expected = tuple(labels)
-        if subject != expected or keywords != expected:
+        if any(values != expected for values in actual):
             raise ExifMetadataWriteError(
                 "ExifTool metadata readback did not match requested labels"
             )
+
+    @staticmethod
+    def _keyword_fields(target: Path) -> tuple[str, ...]:
+        if target.suffix.lower() in VIDEO_EXTENSIONS:
+            return ("XMP-dc:Subject", "Microsoft:Category")
+        return ("XMP-dc:Subject", "IPTC:Keywords")
 
     def _run(self, arguments: list[str]) -> subprocess.CompletedProcess[str]:
         platform_arguments: dict[str, Any] = (

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -1247,6 +1247,8 @@ ApplicationWindow {
         }
 
         onCurrentIndexChanged: {
+            if (taggingDrawer.opened)
+                taggingDrawer.close()
             if (currentIndex === 1) {
                 // Entering Browse: snapshot Search filters (incl. searchField
                 // text) and clear them so Browse shows un-filtered folder

--- a/tests/tagging/test_derivative_export_service.py
+++ b/tests/tagging/test_derivative_export_service.py
@@ -15,6 +15,7 @@ from exif_turbo.tagging.derivative_export_service import (
     DerivativeExportService,
     DerivativeExportStatus,
 )
+from exif_turbo.tagging.sidecar_repository import FilesystemSidecarRepository
 
 
 class FakeMetadataWriter:
@@ -57,17 +58,21 @@ def _index_image(
         for index, label in enumerate(labels, start=1)
     )
     if tags:
+        sidecar = ImageSidecar(
+            source=SidecarSource(filename=image_path.name),
+            updated_at="2026-08-09T12:00:00Z",
+            tags=tags,
+        )
+        revision = FilesystemSidecarRepository().write(
+            image_path, sidecar, expected_revision=None
+        )
         repository.replace_accepted_tags_and_sidecar_state(
             str(image_path),
-            ImageSidecar(
-                source=SidecarSource(filename=image_path.name),
-                updated_at="2026-08-09T12:00:00Z",
-                tags=tags,
-            ),
+            sidecar,
             sidecar_path=f"{image_path}.sidecar.json",
-            sidecar_mtime_ns=1,
-            sidecar_size=1,
-            sidecar_checksum="sha256:test",
+            sidecar_mtime_ns=revision.mtime_ns,
+            sidecar_size=revision.size,
+            sidecar_checksum=revision.sha256,
             sync_status="synced",
         )
 
@@ -102,18 +107,27 @@ def test_create_plan_includes_custom_free_tags(
     source_root.mkdir()
     image_path.write_bytes(b"original")
     _index_image(repo, image_path, "Deer")
+    sidecar_repository = FilesystemSidecarRepository()
+    loaded_sidecar = sidecar_repository.read(image_path)
+    assert loaded_sidecar is not None
+    updated_sidecar = ImageSidecar(
+        source=SidecarSource(filename=image_path.name),
+        updated_at="2026-08-09T12:00:00Z",
+        tags=repo.get_accepted_tags(str(image_path)),
+        free_tags=("Family",),
+    )
+    revision = sidecar_repository.write(
+        image_path,
+        updated_sidecar,
+        expected_revision=loaded_sidecar.revision,
+    )
     repo.replace_accepted_tags_and_sidecar_state(
         str(image_path),
-        ImageSidecar(
-            source=SidecarSource(filename=image_path.name),
-            updated_at="2026-08-09T12:00:00Z",
-            tags=repo.get_accepted_tags(str(image_path)),
-            free_tags=("Family",),
-        ),
+        updated_sidecar,
         sidecar_path=f"{image_path}.sidecar.json",
-        sidecar_mtime_ns=2,
-        sidecar_size=2,
-        sidecar_checksum="sha256:free-tags",
+        sidecar_mtime_ns=revision.mtime_ns,
+        sidecar_size=revision.size,
+        sidecar_checksum=revision.sha256,
         sync_status="synced",
     )
 
@@ -124,6 +138,87 @@ def test_create_plan_includes_custom_free_tags(
 
     # Assert
     assert plan.items[0].labels == ("Deer", "Family")
+
+
+def test_create_plan_sidecar_tags_missing_from_cache_includes_tags(
+    tmp_path: Path, repo: ImageIndexRepository
+) -> None:
+    # Arrange
+    source_root = tmp_path / "source"
+    video_path = source_root / "clip.mp4"
+    source_root.mkdir()
+    video_path.write_bytes(b"original")
+    _index_image(repo, video_path)
+    FilesystemSidecarRepository().write(
+        video_path,
+        ImageSidecar(
+            source=SidecarSource(filename=video_path.name),
+            updated_at="2026-08-15T07:16:50Z",
+            free_tags=("Katzenpfote",),
+        ),
+        expected_revision=None,
+    )
+
+    # Act
+    plan = DerivativeExportService(repo, FakeMetadataWriter()).create_plan(
+        {source_root: "source"}, tmp_path / "output", image_paths=[video_path]
+    )
+
+    # Assert
+    assert plan.items[0].labels == ("Katzenpfote",)
+    assert plan.items[0].planned_status is None
+
+
+def test_create_plan_sidecar_tags_differ_from_cache_uses_sidecar_tags(
+    tmp_path: Path, repo: ImageIndexRepository
+) -> None:
+    # Arrange
+    source_root = tmp_path / "source"
+    image_path = source_root / "photo.jpg"
+    source_root.mkdir()
+    image_path.write_bytes(b"original")
+    _index_image(repo, image_path, "Stale cache tag")
+    sidecar_repository = FilesystemSidecarRepository()
+    loaded_sidecar = sidecar_repository.read(image_path)
+    assert loaded_sidecar is not None
+    sidecar_repository.write(
+        image_path,
+        ImageSidecar(
+            source=SidecarSource(filename=image_path.name),
+            updated_at="2026-08-15T07:16:50Z",
+            free_tags=("Authoritative sidecar tag",),
+        ),
+        expected_revision=loaded_sidecar.revision,
+    )
+
+    # Act
+    plan = DerivativeExportService(repo, FakeMetadataWriter()).create_plan(
+        {source_root: "source"}, tmp_path / "output", image_paths=[image_path]
+    )
+
+    # Assert
+    assert plan.items[0].labels == ("Authoritative sidecar tag",)
+
+
+def test_create_plan_cache_tags_without_sidecar_skips_source(
+    tmp_path: Path, repo: ImageIndexRepository
+) -> None:
+    # Arrange
+    source_root = tmp_path / "source"
+    image_path = source_root / "photo.jpg"
+    source_root.mkdir()
+    image_path.write_bytes(b"original")
+    _index_image(repo, image_path, "Cache-only tag")
+    FilesystemSidecarRepository.sidecar_path(image_path).unlink()
+
+    # Act
+    plan = DerivativeExportService(repo, FakeMetadataWriter()).create_plan(
+        {source_root: "source"}, tmp_path / "output", image_paths=[image_path]
+    )
+
+    # Assert
+    assert plan.items[0].labels == ()
+    assert plan.items[0].planned_status is DerivativeExportStatus.SKIPPED_UNTAGGED
 
 
 def test_create_plan_preserves_embedded_keywords_with_accepted_additions(

--- a/tests/tagging/test_exif_metadata_writer.py
+++ b/tests/tagging/test_exif_metadata_writer.py
@@ -85,6 +85,78 @@ def test_write_keywords_builds_exact_arguments_with_target_last_and_verifies(
     ]
 
 
+def test_write_keywords_mp4_writes_and_verifies_xmp_and_windows_tags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    target = tmp_path / "derivative.mp4"
+    target.write_bytes(b"video")
+    calls: list[list[str]] = []
+
+    def fake_run(
+        arguments: list[str], **_kwargs: object
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(arguments)
+        stdout = (
+            json.dumps(
+                [
+                    {
+                        "XMP-dc:Subject": "Katzenpfote",
+                        "Microsoft:Category": "Katzenpfote",
+                    }
+                ]
+            )
+            if "-json" in arguments
+            else "1 image files updated"
+        )
+        return subprocess.CompletedProcess(arguments, 0, stdout, "")
+
+    monkeypatch.setattr(
+        "exif_turbo.tagging.exif_metadata_writer.find_exiftool",
+        lambda: "C:/tools/exiftool.exe",
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # Act
+    ExifMetadataWriter().write_keywords(target, ("Katzenpfote",))
+
+    # Assert
+    assert calls == [
+        [
+            "C:/tools/exiftool.exe",
+            "-json",
+            "-G1",
+            "-XMP-dc:Subject",
+            "-Microsoft:Category",
+            str(target),
+        ],
+        [
+            "C:/tools/exiftool.exe",
+            "-m",
+            "-overwrite_original",
+            "-XMP-dc:Subject=",
+            "-Microsoft:Category=",
+            str(target),
+        ],
+        [
+            "C:/tools/exiftool.exe",
+            "-m",
+            "-overwrite_original",
+            "-XMP-dc:Subject+=Katzenpfote",
+            "-Microsoft:Category+=Katzenpfote",
+            str(target),
+        ],
+        [
+            "C:/tools/exiftool.exe",
+            "-json",
+            "-G1",
+            "-XMP-dc:Subject",
+            "-Microsoft:Category",
+            str(target),
+        ],
+    ]
+
+
 def test_write_keywords_merges_live_existing_keywords_case_insensitively(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/ui/test_app_controller_tagging.py
+++ b/tests/ui/test_app_controller_tagging.py
@@ -263,6 +263,58 @@ def test_app_controller_tgm_search_resolves_alias(
     assert model.data(model.index(0), model.LabelRole) == "Forests"
 
 
+def test_tagging_drawer_leaving_search_or_browse_closes_drawer(
+    qtbot: QtBot,
+    tagging_controller: tuple[AppController, SearchListModel, Path, Path],
+) -> None:
+    # Arrange
+    controller, search_model, _db_path, _image_path = tagging_controller
+    settings_model = SettingsModel(search_model.cache_dir.parent / "qml-settings.json")
+    filter_proxy = CheckedFilterProxyModel()
+    filter_proxy.setSourceModel(search_model)
+    controller.set_filter_proxy(filter_proxy)
+
+    engine = QQmlApplicationEngine()
+    engine.addImageProvider("preview", PreviewImageProvider())
+    engine.addImageProvider("raw", RawImageProvider())
+    context = engine.rootContext()
+    context.setContextProperty("controller", controller)
+    context.setContextProperty("searchModel", search_model)
+    context.setContextProperty("filteredSearchModel", filter_proxy)
+    context.setContextProperty("exifModel", ExifListModel())
+    context.setContextProperty("folderListModel", FolderListModel())
+    context.setContextProperty("settingsModel", settings_model)
+    context.setContextProperty("thirdPartyLicensesHtml", "")
+    context.setContextProperty("userManualUrl", "")
+    engine.load(QUrl.fromLocalFile(str(_QML_DIR / "Main.qml")))
+    qtbot.waitUntil(lambda: bool(engine.rootObjects()), timeout=5_000)
+    root: QQuickWindow = engine.rootObjects()[0]  # type: ignore[assignment]
+    root.setWidth(1200)
+    root.setHeight(800)
+    root.show()
+    qtbot.waitExposed(root, timeout=3_000)
+
+    drawer = root.findChild(QObject, "taggingDrawer")
+    tab_bar = root.findChild(QQuickItem, "mainTabBar")
+    assert drawer is not None
+    assert tab_bar is not None
+    QMetaObject.invokeMethod(drawer, "openAndFocus", Qt.ConnectionType.DirectConnection)
+    qtbot.waitUntil(lambda: bool(drawer.property("opened")), timeout=3_000)
+
+    # Act / Assert: leave Search.
+    tab_bar.setProperty("currentIndex", 1)
+    qtbot.waitUntil(lambda: not bool(drawer.property("opened")), timeout=3_000)
+
+    # Act / Assert: leave Browse.
+    QMetaObject.invokeMethod(drawer, "openAndFocus", Qt.ConnectionType.DirectConnection)
+    qtbot.waitUntil(lambda: bool(drawer.property("opened")), timeout=3_000)
+    tab_bar.setProperty("currentIndex", 0)
+    qtbot.waitUntil(lambda: not bool(drawer.property("opened")), timeout=3_000)
+
+    engine.deleteLater()
+    qtbot.wait(100)
+
+
 def test_tagging_drawer_clicking_tgm_result_populates_search_field(
     qtbot: QtBot,
     tagging_controller: tuple[AppController, SearchListModel, Path, Path],


### PR DESCRIPTION
## Summary
- read derivative export tags from authoritative sidecars instead of the SQLite cache
- write video tags to portable XMP and Windows Explorer-compatible Microsoft Category metadata
- close the tagging drawer whenever the user leaves Search or Browse

## Validation
- `pytest tests/tagging/test_derivative_export_service.py -q` (16 passed)
- `pytest tests/tagging/test_exif_metadata_writer.py tests/tagging/test_derivative_export_service.py -q` (21 passed)
- `pytest tests/ui/test_app_controller_tagging.py -q` (23 passed)
- verified a real MP4 ExifTool round trip and Windows `System.Keywords` readback