### PR TITLE
Fix Linux release builds

### DIFF
--- a/exif-turbo-rpm.spec
+++ b/exif-turbo-rpm.spec
@@ -4,6 +4,7 @@
 import re
 import sys
 from pathlib import Path
+from PyInstaller.utils.hooks import collect_all
 from PyInstaller.utils.hooks import collect_data_files
 
 sys.path.insert(0, str(Path('scripts').resolve()))
@@ -45,12 +46,15 @@ _common_hiddenimports = [
     'av',
 ]
 
+_wec_datas, _wec_bins, _wec_hidden = collect_all('PySide6.QtWebEngineCore')
+_weq_datas, _weq_bins, _weq_hidden = collect_all('PySide6.QtWebEngineQuick')
+
 a_gui = Analysis(
     ['src/exif_turbo/app.py'],
     pathex=['src'],
-    binaries=[],
-    datas=_common_datas,
-    hiddenimports=_common_hiddenimports,
+    binaries=_wec_bins + _weq_bins,
+    datas=_common_datas + _wec_datas + _weq_datas,
+    hiddenimports=_common_hiddenimports + _wec_hidden + _weq_hidden,
     hookspath=['hooks'],
     hooksconfig={},
     runtime_hooks=[],

--- a/scripts/build_deb.py
+++ b/scripts/build_deb.py
@@ -39,8 +39,11 @@ apt-get install -y -q \
     libminizip1t64
 python3 -m venv /build-venv
 . /build-venv/bin/activate
-pip install --quiet --index-url https://download.pytorch.org/whl/cpu torch torchvision
-pip install --quiet -e '.[build]'
+pip install --quiet \
+    --index-url https://download.pytorch.org/whl/cpu \
+    --extra-index-url https://pypi.org/simple \
+    torch torchvision
+pip install --quiet --index-url https://pypi.org/simple -e '.[build]'
 python scripts/build_linux.py --deb-only --deb-arch "${TARGET_DEB_ARCH}"
 """
 

--- a/scripts/build_rpm.py
+++ b/scripts/build_rpm.py
@@ -31,8 +31,11 @@ dnf install -y -q \
     libXcomposite libXdamage libXrandr libxshmfence
 python3.11 -m venv /build-venv
 . /build-venv/bin/activate
-pip install --quiet --index-url https://download.pytorch.org/whl/cpu torch torchvision
-pip install --quiet -e '.[build]'
+pip install --quiet \
+    --index-url https://download.pytorch.org/whl/cpu \
+    --extra-index-url https://pypi.org/simple \
+    torch torchvision
+pip install --quiet --index-url https://pypi.org/simple -e '.[build]'
 python scripts/build_linux.py --rpm-only
 """
 

--- a/scripts/stage_runtime_licenses.py
+++ b/scripts/stage_runtime_licenses.py
@@ -157,6 +157,15 @@ def _safe_filename(path: Path, used: set[str]) -> str:
 def _python_license_file() -> Path:
     installed_base = Path(str(sysconfig.get_config_var("installed_base")))
     candidates = [installed_base / "LICENSE.txt", installed_base / "LICENSE"]
+    stdlib = sysconfig.get_path("stdlib")
+    if stdlib:
+        candidates.extend((Path(stdlib) / "LICENSE.txt", Path(stdlib) / "LICENSE"))
+    version = sysconfig.get_config_var("py_version_short")
+    if version:
+        candidates.append(
+            installed_base / "share" / "doc" / f"python{version}" / "copyright"
+        )
+    candidates.append(installed_base / "share" / "doc" / "python3" / "copyright")
     framework_dir = next(
         (parent for parent in installed_base.parents if parent.name == "Python.framework"),
         None,

--- a/tests/scripts/test_linux_container_builds.py
+++ b/tests/scripts/test_linux_container_builds.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts import build_deb, build_rpm
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_linux_container_builds_resolve_project_dependencies_from_pypi() -> None:
+    # Arrange
+    torch_dependency_index = "--extra-index-url https://pypi.org/simple"
+    project_install = (
+        "pip install --quiet --index-url https://pypi.org/simple -e '.[build]'"
+    )
+
+    # Act
+    scripts = (build_deb.CONTAINER_SCRIPT, build_rpm.CONTAINER_SCRIPT)
+
+    # Assert
+    assert all(
+        torch_dependency_index in script and project_install in script
+        for script in scripts
+    )
+
+
+def test_rpm_spec_explicitly_collects_qt_webengine_binary_payload() -> None:
+    # Arrange / Act
+    source = (_REPO_ROOT / "exif-turbo-rpm.spec").read_text(encoding="utf-8")
+
+    # Assert
+    assert "collect_all('PySide6.QtWebEngineCore')" in source
+    assert "collect_all('PySide6.QtWebEngineQuick')" in source
+    assert "binaries=_wec_bins + _weq_bins" in source

--- a/tests/scripts/test_stage_runtime_licenses.py
+++ b/tests/scripts/test_stage_runtime_licenses.py
@@ -80,6 +80,62 @@ def test_python_license_file_homebrew_framework_returns_formula_license(
     assert result == license_file
 
 
+def test_python_license_file_ubuntu_returns_versioned_package_copyright(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    installed_base = tmp_path / "usr"
+    license_file = installed_base / "share" / "doc" / "python3.12" / "copyright"
+    license_file.parent.mkdir(parents=True)
+    license_file.write_text("Python terms", encoding="utf-8")
+    config_vars = {
+        "installed_base": str(installed_base),
+        "py_version_short": "3.12",
+    }
+    monkeypatch.setattr(
+        stage_runtime_licenses.sysconfig,
+        "get_config_var",
+        config_vars.get,
+    )
+
+    # Act
+    result = stage_runtime_licenses._python_license_file()
+
+    # Assert
+    assert result == license_file
+
+
+def test_python_license_file_almalinux_returns_stdlib_license(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    installed_base = tmp_path / "usr"
+    stdlib = installed_base / "lib64" / "python3.11"
+    license_file = stdlib / "LICENSE.txt"
+    license_file.parent.mkdir(parents=True)
+    license_file.write_text("Python terms", encoding="utf-8")
+    config_vars = {
+        "installed_base": str(installed_base),
+        "py_version_short": "3.11",
+    }
+    monkeypatch.setattr(
+        stage_runtime_licenses.sysconfig,
+        "get_config_var",
+        config_vars.get,
+    )
+    monkeypatch.setattr(
+        stage_runtime_licenses.sysconfig,
+        "get_path",
+        lambda _name: str(stdlib),
+    )
+
+    # Act
+    result = stage_runtime_licenses._python_license_file()
+
+    # Assert
+    assert result == license_file
+
+
 def test_runtime_distributions_transitive_and_inactive_marker_resolves_active_closure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- resolve CPU-only Torch from the PyTorch index while allowing ordinary dependencies from PyPI
- resolve CPython license files on Ubuntu and AlmaLinux build images
- explicitly collect the QtWebEngine binary payload in the RPM PyInstaller spec
- add focused regression coverage for Linux container commands and license discovery

## Testing

- `pytest tests/scripts/test_linux_container_builds.py tests/scripts/test_stage_runtime_licenses.py tests/scripts/test_audit_release_artifact.py -q` (16 passed)

## Validation note

The updated dependency and license paths were exercised in the Linux containers. The final end-to-end RPM build was interrupted before the last RPM spec adjustment completed, so CI or a fresh local RPM build should provide final artifact validation.