### PR TITLE
fix: use SVG tagging icon for Fedora-compatible rendering

### DIFF
--- a/src/exif_turbo/assets/tag_icon.svg
+++ b/src/exif_turbo/assets/tag_icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M3 11.5V5a2 2 0 0 1 2-2h6.5a2 2 0 0 1 1.4.6l7.5 7.5a2 2 0 0 1 0 2.8l-6.2 6.2a2 2 0 0 1-2.8 0l-7.5-7.5A2 2 0 0 1 3 11.5Z" stroke="#8F9AA6" stroke-width="1.8" stroke-linejoin="round"/>
+  <circle cx="8.25" cy="8.25" r="1.45" fill="#8F9AA6"/>
+</svg>

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -1277,8 +1277,9 @@ ApplicationWindow {
         z: 11
         visible: !_isLocked && (mainTabBar.currentIndex === 0 || mainTabBar.currentIndex === 1)
         enabled: !_isLocked
-        text: "\uD83C\uDFF7\uFE0F"
-        font.pixelSize: 17
+        icon.source: "../../assets/tag_icon.svg"
+        icon.width: 20
+        icon.height: 20
         onClicked: taggingDrawer.opened ? taggingDrawer.close() : taggingDrawer.openAndFocus()
         ToolTip.text: qsTr("Open tagging (Ctrl+T)")
         ToolTip.visible: hovered


### PR DESCRIPTION
## Summary
- replace the emoji-based tagging button label in Main.qml with a bundled SVG icon
- add `src/exif_turbo/assets/tag_icon.svg` and wire it into the tagging tool button
- set explicit icon dimensions for consistent rendering across Linux distros

## Motivation
Some Fedora setups do not render the emoji glyph reliably in the toolbar, leaving an inconsistent or missing tagging button icon.

## Testing
- manually verified the QML change builds and the tagging button uses the SVG asset
