### PR TITLE
Fix result scrolling while tagging drawer is open

### DIFF
--- a/src/exif_turbo/ui/scroll_fix.py
+++ b/src/exif_turbo/ui/scroll_fix.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from PySide6.QtCore import QEvent, QObject
+from PySide6.QtCore import QEvent, QObject, QPointF
 from PySide6.QtQuick import QQuickItem
 
 
@@ -64,8 +64,8 @@ class ListScrollFix(QObject):
         self._overlay: QQuickItem | None = None
 
     # ------------------------------------------------------------------
-    def _overlay_has_open_popup(self) -> bool:
-        """Return ``True`` while a Popup/Dialog/Menu is shown in the overlay.
+    def _overlay_contains(self, scene_position: QPointF) -> bool:
+        """Return ``True`` when visible overlay content covers the position.
 
         Foreground popups (their ``QQuickPopupItem``) are parented to the
         ``ApplicationWindow`` overlay only while open.  ``ApplicationWindow``'s
@@ -73,9 +73,9 @@ class ListScrollFix(QObject):
         ``property("overlay")``, so the ``QQuickOverlay`` item is located once
         by class name and cached.
 
-        While a popup is open the background lists must not steal the wheel
-        event, otherwise scrolling over e.g. the Third-Party Licenses dialog
-        moves the search results behind it instead of the dialog content.
+        Background lists must not steal wheel events from overlay content.
+        Checking the position is important for non-modal drawers, which leave
+        the rest of the window interactive while their popup item is open.
         """
         overlay = self._overlay
         if overlay is None:
@@ -86,16 +86,19 @@ class ListScrollFix(QObject):
                     break
         if overlay is None:
             return False
-        return any(child.isVisible() for child in overlay.childItems())
+        return any(
+            child.isVisible()
+            and child.boundingRect().contains(child.mapFromScene(scene_position))
+            for child in overlay.childItems()
+        )
 
     # ------------------------------------------------------------------
     def eventFilter(self, obj: QObject, event: QEvent) -> bool:  # noqa: N802
         if event.type() != QEvent.Type.Wheel:
             return False
 
-        # A foreground popup/dialog owns the wheel event — let it through so
-        # the popup (not the background list) scrolls.
-        if self._overlay_has_open_popup():
+        # Foreground overlay content under the pointer owns the wheel event.
+        if self._overlay_contains(event.position()):  # type: ignore[attr-defined]
             return False
 
         lst: QQuickItem | None = self._window.findChild(QQuickItem, self._name)

--- a/tests/ui/test_results_scroll.py
+++ b/tests/ui/test_results_scroll.py
@@ -27,6 +27,8 @@ import pytest
 from PIL import Image
 from PySide6.QtCore import (
     QCoreApplication,
+    QMetaObject,
+    QObject,
     QPoint,
     QPointF,
     Qt,
@@ -206,6 +208,32 @@ class TestResultsListWheelScroll:
         assert content_y == pytest.approx(_ROW_HEIGHT, abs=1.0), (
             f"Expected contentY={_ROW_HEIGHT} after one notch, got {content_y:.1f}. "
             "pixelDelta branch may still be taken on Linux."
+        )
+
+    def test_single_notch_with_tagging_drawer_open_scrolls_one_row(
+        self,
+        qtbot: QtBot,
+        scroll_window: tuple[AppController, QQuickItem, QQuickWindow],
+    ) -> None:
+        """An open non-modal tagging drawer must not disable result scrolling."""
+        # Arrange
+        _controller, results_list, qml_window = scroll_window
+        drawer = qml_window.findChild(QObject, "taggingDrawer")
+        assert drawer is not None
+        results_list.setProperty("contentY", 0.0)
+        QMetaObject.invokeMethod(drawer, "open")
+        qtbot.waitUntil(lambda: bool(drawer.property("opened")), timeout=2000)
+        QCoreApplication.processEvents()
+
+        # Act
+        _send_wheel(results_list, qml_window, angle_delta_y=-120, pixel_delta_y=-3)
+        qtbot.wait(50)
+
+        # Assert
+        content_y = float(results_list.property("contentY"))
+        assert content_y == pytest.approx(_ROW_HEIGHT, abs=1.0), (
+            f"Expected contentY={_ROW_HEIGHT} with tagging drawer open, "
+            f"got {content_y:.1f}."
         )
 
     def test_subnotch_events_accumulate_to_one_row(


### PR DESCRIPTION
## Summary
- keep one-row-per-notch scrolling active while the non-modal tagging drawer is open
- yield wheel events only when visible overlay content is under the pointer
- add regression coverage for result scrolling with the tagging drawer open

## Tests
- pytest tests/ui/test_results_scroll.py -q --timeout=120 --timeout-method=thread (4 passed)
- pytest tests/ui/test_third_party_licenses_wheel_scroll.py -q --timeout=120 --timeout-method=thread (2 passed)