### PR TITLE
Add bulk tag copying

### DIFF
--- a/src/exif_turbo/i18n/locales/de/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/de/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-14 16:48+0200\n"
+"POT-Creation-Date: 2026-08-17 20:45+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -22,125 +22,125 @@ msgstr ""
 msgid "PyTorch is not available on macOS Intel for Python 3.13+."
 msgstr "PyTorch ist auf macOS Intel für Python 3.13+ nicht verfügbar."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:217
+#: src/exif_turbo/ui/view_models/app_controller.py:218
 msgid "Enter the database password to continue"
 msgstr "Datenbankpasswort eingeben, um fortzufahren"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:990
+#: src/exif_turbo/ui/view_models/app_controller.py:992
 msgid "Selecting all matching images…"
 msgstr "Alle passenden Bilder werden ausgewählt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1000
+#: src/exif_turbo/ui/view_models/app_controller.py:1002
 msgid "Deselecting all matching images…"
 msgstr "Auswahl aller passenden Bilder wird aufgehoben…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1010
+#: src/exif_turbo/ui/view_models/app_controller.py:1012
 msgid "Inverting selection…"
 msgstr "Auswahl wird umgekehrt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1024
+#: src/exif_turbo/ui/view_models/app_controller.py:1026
 msgid "Selecting images without a cached thumbnail…"
 msgstr "Bilder ohne gecachte Miniaturansicht werden ausgewählt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1039
+#: src/exif_turbo/ui/view_models/app_controller.py:1041
 msgid "No marked images to delete."
 msgstr "Keine markierten Bilder zum Löschen."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1043
+#: src/exif_turbo/ui/view_models/app_controller.py:1045
 msgid "Deleting marked images…"
 msgstr "Markierte Bilder werden gelöscht…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1053
+#: src/exif_turbo/ui/view_models/app_controller.py:1055
 msgid "No marked images to export."
 msgstr "Keine markierten Bilder zum Exportieren."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1058
+#: src/exif_turbo/ui/view_models/app_controller.py:1060
 msgid "Exporting metadata…"
 msgstr "Metadaten werden exportiert…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1160
+#: src/exif_turbo/ui/view_models/app_controller.py:1162
 #, python-brace-format
 msgid "Deleted {n} image(s)."
 msgstr "{n} Bild(er) gelöscht."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1164
+#: src/exif_turbo/ui/view_models/app_controller.py:1166
 #, python-brace-format
 msgid "{n} were already missing."
 msgstr "{n} waren bereits nicht mehr vorhanden."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1170
+#: src/exif_turbo/ui/view_models/app_controller.py:1172
 #, python-brace-format
 msgid "{n} could not be deleted."
 msgstr "{n} konnten nicht gelöscht werden."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1180
+#: src/exif_turbo/ui/view_models/app_controller.py:1182
 #, python-brace-format
 msgid "Exported {count} image(s) to {name}"
 msgstr "{count} Bild(er) nach {name} exportiert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1190
-#: src/exif_turbo/ui/view_models/app_controller.py:1272
+#: src/exif_turbo/ui/view_models/app_controller.py:1192
+#: src/exif_turbo/ui/view_models/app_controller.py:1274
 #, python-brace-format
 msgid "Operation failed: {}"
 msgstr "Vorgang fehlgeschlagen: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1196
-#: src/exif_turbo/ui/view_models/app_controller.py:1278
+#: src/exif_turbo/ui/view_models/app_controller.py:1198
+#: src/exif_turbo/ui/view_models/app_controller.py:1280
 msgid "Operation canceled."
 msgstr "Vorgang abgebrochen."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1366
+#: src/exif_turbo/ui/view_models/app_controller.py:1368
 msgid "Wrong password — please try again."
 msgstr "Falsches Passwort — bitte erneut versuchen."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1378
+#: src/exif_turbo/ui/view_models/app_controller.py:1380
 #, python-brace-format
 msgid "Failed to open database: {error}"
 msgstr "Datenbank konnte nicht geöffnet werden: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1404
+#: src/exif_turbo/ui/view_models/app_controller.py:1406
 msgid "Database is locked."
 msgstr "Die Datenbank ist gesperrt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1409
+#: src/exif_turbo/ui/view_models/app_controller.py:1411
 msgid "Cannot change password while indexing or thumb-building is running."
 msgstr ""
 "Das Passwort kann nicht geändert werden, während Indizierung oder "
 "Miniaturansichterstellung läuft."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1413
+#: src/exif_turbo/ui/view_models/app_controller.py:1415
 msgid "Current password is incorrect."
 msgstr "Das aktuelle Passwort ist falsch."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1416
+#: src/exif_turbo/ui/view_models/app_controller.py:1418
 msgid "New password must not be empty."
 msgstr "Das neue Passwort darf nicht leer sein."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1420
+#: src/exif_turbo/ui/view_models/app_controller.py:1422
 msgid "New password must differ from the current password."
 msgstr "Das neue Passwort muss sich vom aktuellen unterscheiden."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1438
+#: src/exif_turbo/ui/view_models/app_controller.py:1440
 msgid "Changing password…"
 msgstr "Passwort wird geändert…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1479
+#: src/exif_turbo/ui/view_models/app_controller.py:1481
 #, python-brace-format
 msgid "Database password changed, but reopening failed: {error}"
 msgstr ""
 "Datenbankpasswort geändert, aber das erneute Öffnen ist fehlgeschlagen: "
 "{error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1489
+#: src/exif_turbo/ui/view_models/app_controller.py:1491
 msgid "Password changed successfully."
 msgstr "Passwort erfolgreich geändert."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1530
+#: src/exif_turbo/ui/view_models/app_controller.py:1532
 #, python-brace-format
 msgid "Failed to change password: {error}"
 msgstr "Passwortänderung fehlgeschlagen: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1535
+#: src/exif_turbo/ui/view_models/app_controller.py:1537
 #, python-brace-format
 msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
@@ -150,229 +150,246 @@ msgstr ""
 "neu verschlüsselt werden ({error}). Der Cache wurde geleert und wird neu "
 "erstellt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2376
+#: src/exif_turbo/ui/view_models/app_controller.py:2378
 msgid "Folder list reloaded."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2613
+#: src/exif_turbo/ui/view_models/app_controller.py:2615
 #, python-brace-format
 msgid "Folder already tracked: {}"
 msgstr "Ordner bereits verfolgt: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2640
+#: src/exif_turbo/ui/view_models/app_controller.py:2642
 msgid "Removing folder…"
 msgstr "Ordner wird entfernt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2812
+#: src/exif_turbo/ui/view_models/app_controller.py:2814
 msgid "Folder not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2818
+#: src/exif_turbo/ui/view_models/app_controller.py:2820
 #, python-brace-format
 msgid "Folder not accessible: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2857
+#: src/exif_turbo/ui/view_models/app_controller.py:2859
 #, python-brace-format
 msgid "Indexing {}…"
 msgstr "Indizierung von {}…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2893
+#: src/exif_turbo/ui/view_models/app_controller.py:2895
 #, python-brace-format
 msgid "Indexed {count} images ({errors} skipped due to errors)"
 msgstr "{count} Bilder indiziert ({errors} aufgrund von Fehlern übersprungen)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2898
+#: src/exif_turbo/ui/view_models/app_controller.py:2900
 #, python-brace-format
 msgid "Indexed {} images"
 msgstr "{} Bilder indiziert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2931
+#: src/exif_turbo/ui/view_models/app_controller.py:2933
 #, python-brace-format
 msgid "Index failed: {}"
 msgstr "Indizierung fehlgeschlagen: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2963
+#: src/exif_turbo/ui/view_models/app_controller.py:2965
 msgid "Index canceled"
 msgstr "Indizierung abgebrochen"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2983
+#: src/exif_turbo/ui/view_models/app_controller.py:2985
 msgid "Canceling…"
 msgstr "Abbrechen…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3181
+#: src/exif_turbo/ui/view_models/app_controller.py:3183
 #, python-brace-format
 msgid "AI full rescan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3183
+#: src/exif_turbo/ui/view_models/app_controller.py:3185
 #, python-brace-format
 msgid "AI-Scan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3185
+#: src/exif_turbo/ui/view_models/app_controller.py:3187
 #, python-brace-format
 msgid "{n} file(s) could not be processed."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3192
+#: src/exif_turbo/ui/view_models/app_controller.py:3194
 #, python-brace-format
 msgid "AI full rescan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3194
+#: src/exif_turbo/ui/view_models/app_controller.py:3196
 #, python-brace-format
 msgid "AI-Scan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3201
+#: src/exif_turbo/ui/view_models/app_controller.py:3203
 #, python-brace-format
 msgid "AI full rescan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3205
+#: src/exif_turbo/ui/view_models/app_controller.py:3207
 #, python-brace-format
 msgid "AI-Scan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3231
+#: src/exif_turbo/ui/view_models/app_controller.py:3233
 #, python-brace-format
 msgid "Built {built} preview(s) of {total}."
 msgstr "{built} von {total} Vorschaubilder erstellt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3235
+#: src/exif_turbo/ui/view_models/app_controller.py:3237
 #, python-brace-format
 msgid "{n} image(s) skipped — too large to decode safely."
 msgstr "{n} Bild(er) übersprungen — zu groß zum sicheren Dekodieren."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3245
+#: src/exif_turbo/ui/view_models/app_controller.py:3247
 #, python-brace-format
 msgid "Preview build failed: {error}"
 msgstr "Vorschaubilderstellung fehlgeschlagen: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3253
+#: src/exif_turbo/ui/view_models/app_controller.py:3255
 #, python-brace-format
 msgid "Preview build canceled ({built} of {total} done)."
 msgstr "Vorschaubilderstellung abgebrochen ({built} von {total} fertig)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3266
+#: src/exif_turbo/ui/view_models/app_controller.py:3268
 msgid "Cancel the running preview build before clearing the cache."
 msgstr ""
 "Bitte die laufende Vorschaubilderstellung abbrechen, bevor der Cache "
 "geleert wird."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3275
+#: src/exif_turbo/ui/view_models/app_controller.py:3277
 #, python-brace-format
 msgid "Failed to clear preview cache: {error}"
 msgstr "Löschen des Vorschau-Caches fehlgeschlagen: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3281
+#: src/exif_turbo/ui/view_models/app_controller.py:3283
 #, python-brace-format
 msgid "Removed {n} cached preview(s)."
 msgstr "{n} gecachtes Vorschaubild(er) entfernt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3406
+#: src/exif_turbo/ui/view_models/app_controller.py:3408
 msgid "Image copied to clipboard"
 msgstr "Bild in Zwischenablage kopiert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3410
+#: src/exif_turbo/ui/view_models/app_controller.py:3412
 msgid "Path copied to clipboard"
 msgstr "Pfad in Zwischenablage kopiert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3423
+#: src/exif_turbo/ui/view_models/app_controller.py:3425
 msgid "Preview source file not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3430
+#: src/exif_turbo/ui/view_models/app_controller.py:3432
 msgid "Preview saved"
 msgstr "Vorschau gespeichert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3442
-#: src/exif_turbo/ui/view_models/app_controller.py:3451
+#: src/exif_turbo/ui/view_models/app_controller.py:3444
+#: src/exif_turbo/ui/view_models/app_controller.py:3453
 msgid "File not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3447
+#: src/exif_turbo/ui/view_models/app_controller.py:3449
 msgid "Original saved"
 msgstr "Original gespeichert"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3511
+#: src/exif_turbo/ui/view_models/app_controller.py:3513
 msgid "Resetting database…"
 msgstr "Datenbank wird zurückgesetzt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3536
+#: src/exif_turbo/ui/view_models/app_controller.py:3538
 msgid "Database reset"
 msgstr "Datenbank zurückgesetzt"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3584
+#: src/exif_turbo/ui/view_models/app_controller.py:3586
 #, python-brace-format
 msgid "TGM source diagnostics: {}"
 msgstr "TGM-Quelldiagnosen: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3968
+#: src/exif_turbo/ui/view_models/app_controller.py:3949
+msgid "Choose whether to add or replace tags."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3960
+msgid "Choose a folder in Browse first."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3977
+msgid "Choose a valid copy target."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:4033
 #, python-brace-format
 msgid "Removed from {} image(s). Already absent: {}. Problems: {}."
 msgstr "Von {} Bild(ern) entfernt. Bereits nicht vorhanden: {}. Probleme: {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3972
+#: src/exif_turbo/ui/view_models/app_controller.py:4037
+#, python-brace-format
+msgid "Copied tags to {} image(s). Unchanged: {}. Problems: {}."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:4041
 #, python-brace-format
 msgid "Added to {} image(s). Already tagged: {}. Problems: {}."
 msgstr "Zu {} Bild(ern) hinzugefügt. Bereits verschlagwortet: {}. Probleme: {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3976
+#: src/exif_turbo/ui/view_models/app_controller.py:4045
 #, python-brace-format
 msgid "Canceled. {}"
 msgstr "Abgebrochen. {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4068
+#: src/exif_turbo/ui/view_models/app_controller.py:4138
 #, python-brace-format
 msgid "Created derivative: {}"
 msgstr "Derivat erstellt: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4070
+#: src/exif_turbo/ui/view_models/app_controller.py:4140
 msgid "Created 1 derivative."
 msgstr "1 Derivat erstellt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4074
+#: src/exif_turbo/ui/view_models/app_controller.py:4144
 #, python-brace-format
 msgid "Created {} derivatives in {}."
 msgstr "{} Derivate in {} erstellt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4079
+#: src/exif_turbo/ui/view_models/app_controller.py:4149
 #, python-brace-format
 msgid "Created {} derivatives."
 msgstr "{} Derivate erstellt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4081
+#: src/exif_turbo/ui/view_models/app_controller.py:4151
 msgid "No derivatives were created."
 msgstr "Keine Derivate wurden erstellt."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4084
+#: src/exif_turbo/ui/view_models/app_controller.py:4154
 #, python-brace-format
 msgid "{} image(s) had no accepted tags."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4088
+#: src/exif_turbo/ui/view_models/app_controller.py:4158
 #, python-brace-format
 msgid "{} destination file(s) already existed."
 msgstr "{} Zieldatei(en) war(en) bereits vorhanden."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4091
+#: src/exif_turbo/ui/view_models/app_controller.py:4161
 #, python-brace-format
 msgid "{} derivative(s) failed."
 msgstr "{} Derivat(e) fehlgeschlagen."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4105
+#: src/exif_turbo/ui/view_models/app_controller.py:4175
 #, python-brace-format
 msgid "First failure ({}): {}"
 msgstr "Erster Fehler ({}): {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4108
+#: src/exif_turbo/ui/view_models/app_controller.py:4178
 #, python-brace-format
 msgid "{} derivative(s) canceled."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4240
+#: src/exif_turbo/ui/view_models/app_controller.py:4311
 #, python-brace-format
 msgid ""
 "Original data source not attached: {source} — attach or mount this folder"
@@ -381,26 +398,26 @@ msgstr ""
 "Originale Datenquelle nicht angehängt: {source} — Hängen Sie diesen "
 "Ordner an oder binden Sie ihn ein, um Dateien zu öffnen."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4247
+#: src/exif_turbo/ui/view_models/app_controller.py:4318
 #, python-brace-format
 msgid "File not found: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4402
+#: src/exif_turbo/ui/view_models/app_controller.py:4473
 msgid "Cleaning up cache…"
 msgstr "Cache wird bereinigt…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4422
+#: src/exif_turbo/ui/view_models/app_controller.py:4493
 #, python-brace-format
 msgid "Indexing… {} (scanning)"
 msgstr "Indizierung… {} (Suche)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4424
+#: src/exif_turbo/ui/view_models/app_controller.py:4495
 #, python-brace-format
 msgid "Indexing… 0 / {}"
 msgstr "Indizierung… 0 / {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4426
+#: src/exif_turbo/ui/view_models/app_controller.py:4497
 #, python-brace-format
 msgid "Indexing… {} / {}"
 msgstr "Indizierung… {} / {}"
@@ -535,6 +552,12 @@ msgstr "Alle"
 #: QML
 msgid "All %1 previews are cached"
 msgstr "Alle %1 Vorschaubilder zwischengespeichert"
+
+#: QML
+msgid ""
+"All accepted and custom tags on each target image will be replaced. This "
+"cannot be undone."
+msgstr ""
 
 #: QML
 msgid "All files (*)"
@@ -680,6 +703,10 @@ msgid ""
 msgstr ""
 
 #: QML
+msgid "Copies accepted and custom tags. The current image is excluded."
+msgstr ""
+
+#: QML
 msgid "Copy"
 msgstr "Kopieren"
 
@@ -688,8 +715,20 @@ msgid "Copy Image to Clipboard"
 msgstr "Bild in Zwischenablage kopieren"
 
 #: QML
+msgid "Copy Tags"
+msgstr ""
+
+#: QML
 msgid "Copy preview image to clipboard"
 msgstr "Vorschaubild in Zwischenablage kopieren"
+
+#: QML
+msgid "Copy tags to other images"
+msgstr ""
+
+#: QML
+msgid "Copying tags"
+msgstr ""
 
 #: QML
 msgid "Create Database"
@@ -708,8 +747,16 @@ msgstr ""
 "Suche und Indizierung von Bild-EXIF-Metadaten."
 
 #: QML
+msgid "Current folder (%1)"
+msgstr ""
+
+#: QML
 msgid "Current password"
 msgstr "Aktuelles Passwort"
+
+#: QML
+msgid "Current search results (%1)"
+msgstr ""
 
 #: QML
 msgid "Custom tags"
@@ -1045,6 +1092,10 @@ msgid "Jump to this image in the Browse tab"
 msgstr ""
 
 #: QML
+msgid "Keep target tags and add missing source tags"
+msgstr ""
+
+#: QML
 msgid "Language"
 msgstr "Sprache"
 
@@ -1077,6 +1128,10 @@ msgstr "METADATEN"
 #: QML
 msgid "Managed Folders"
 msgstr "Verwaltete Ordner"
+
+#: QML
+msgid "Marked images (%1)"
+msgstr "Markierte Bilder (%1)"
 
 #: QML
 msgid "Meaning"
@@ -1320,6 +1375,10 @@ msgid "Remove from selected image"
 msgstr "Vom ausgewählten Bild entfernen"
 
 #: QML
+msgid "Remove target tags before copying source tags"
+msgstr ""
+
+#: QML
 msgid "Remove this folder and delete its indexed images"
 msgstr "Diesen Ordner entfernen und seine indizierten Bilder löschen"
 
@@ -1335,6 +1394,14 @@ msgstr ""
 #: QML
 msgid "Render preview-cache JPEGs for this folder"
 msgstr "Vorschau-Cache-JPEGs für diesen Ordner rendern"
+
+#: QML
+msgid "Replace"
+msgstr ""
+
+#: QML
+msgid "Replace tags on target images?"
+msgstr ""
 
 #: QML
 msgid "Rescan"

--- a/src/exif_turbo/i18n/locales/fr/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/fr/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-14 16:48+0200\n"
+"POT-Creation-Date: 2026-08-17 20:45+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -22,125 +22,125 @@ msgstr ""
 msgid "PyTorch is not available on macOS Intel for Python 3.13+."
 msgstr "PyTorch n’est pas disponible sur macOS Intel pour Python 3.13+."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:217
+#: src/exif_turbo/ui/view_models/app_controller.py:218
 msgid "Enter the database password to continue"
 msgstr "Saisir le mot de passe de la base de données pour continuer"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:990
+#: src/exif_turbo/ui/view_models/app_controller.py:992
 msgid "Selecting all matching images…"
 msgstr "Sélection de toutes les images correspondantes…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1000
+#: src/exif_turbo/ui/view_models/app_controller.py:1002
 msgid "Deselecting all matching images…"
 msgstr "Désélection de toutes les images correspondantes…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1010
+#: src/exif_turbo/ui/view_models/app_controller.py:1012
 msgid "Inverting selection…"
 msgstr "Inversion de la sélection…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1024
+#: src/exif_turbo/ui/view_models/app_controller.py:1026
 msgid "Selecting images without a cached thumbnail…"
 msgstr "Sélection des images sans miniature en cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1039
+#: src/exif_turbo/ui/view_models/app_controller.py:1041
 msgid "No marked images to delete."
 msgstr "Aucune image marquée à supprimer."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1043
+#: src/exif_turbo/ui/view_models/app_controller.py:1045
 msgid "Deleting marked images…"
 msgstr "Suppression des images marquées…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1053
+#: src/exif_turbo/ui/view_models/app_controller.py:1055
 msgid "No marked images to export."
 msgstr "Aucune image marquée à exporter."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1058
+#: src/exif_turbo/ui/view_models/app_controller.py:1060
 msgid "Exporting metadata…"
 msgstr "Exportation des métadonnées…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1160
+#: src/exif_turbo/ui/view_models/app_controller.py:1162
 #, python-brace-format
 msgid "Deleted {n} image(s)."
 msgstr "{n} image(s) supprimée(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1164
+#: src/exif_turbo/ui/view_models/app_controller.py:1166
 #, python-brace-format
 msgid "{n} were already missing."
 msgstr "{n} étaient déjà manquantes."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1170
+#: src/exif_turbo/ui/view_models/app_controller.py:1172
 #, python-brace-format
 msgid "{n} could not be deleted."
 msgstr "{n} n’ont pas pu être supprimées."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1180
+#: src/exif_turbo/ui/view_models/app_controller.py:1182
 #, python-brace-format
 msgid "Exported {count} image(s) to {name}"
 msgstr "{count} image(s) exportée(s) vers {name}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1190
-#: src/exif_turbo/ui/view_models/app_controller.py:1272
+#: src/exif_turbo/ui/view_models/app_controller.py:1192
+#: src/exif_turbo/ui/view_models/app_controller.py:1274
 #, python-brace-format
 msgid "Operation failed: {}"
 msgstr "Opération échouée : {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1196
-#: src/exif_turbo/ui/view_models/app_controller.py:1278
+#: src/exif_turbo/ui/view_models/app_controller.py:1198
+#: src/exif_turbo/ui/view_models/app_controller.py:1280
 msgid "Operation canceled."
 msgstr "Opération annulée."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1366
+#: src/exif_turbo/ui/view_models/app_controller.py:1368
 msgid "Wrong password — please try again."
 msgstr "Mot de passe incorrect — veuillez réessayer."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1378
+#: src/exif_turbo/ui/view_models/app_controller.py:1380
 #, python-brace-format
 msgid "Failed to open database: {error}"
 msgstr "Échec de l’ouverture de la base de données : {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1404
+#: src/exif_turbo/ui/view_models/app_controller.py:1406
 msgid "Database is locked."
 msgstr "La base de données est verrouillée."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1409
+#: src/exif_turbo/ui/view_models/app_controller.py:1411
 msgid "Cannot change password while indexing or thumb-building is running."
 msgstr ""
 "Impossible de changer le mot de passe pendant l’indexation ou la création"
 " des miniatures."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1413
+#: src/exif_turbo/ui/view_models/app_controller.py:1415
 msgid "Current password is incorrect."
 msgstr "Le mot de passe actuel est incorrect."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1416
+#: src/exif_turbo/ui/view_models/app_controller.py:1418
 msgid "New password must not be empty."
 msgstr "Le nouveau mot de passe ne doit pas être vide."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1420
+#: src/exif_turbo/ui/view_models/app_controller.py:1422
 msgid "New password must differ from the current password."
 msgstr "Le nouveau mot de passe doit être différent de l’actuel."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1438
+#: src/exif_turbo/ui/view_models/app_controller.py:1440
 msgid "Changing password…"
 msgstr "Changement du mot de passe…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1479
+#: src/exif_turbo/ui/view_models/app_controller.py:1481
 #, python-brace-format
 msgid "Database password changed, but reopening failed: {error}"
 msgstr ""
 "Mot de passe de la base de données modifié, mais la réouverture a échoué "
 ": {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1489
+#: src/exif_turbo/ui/view_models/app_controller.py:1491
 msgid "Password changed successfully."
 msgstr "Mot de passe modifié avec succès."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1530
+#: src/exif_turbo/ui/view_models/app_controller.py:1532
 #, python-brace-format
 msgid "Failed to change password: {error}"
 msgstr "Échec du changement de mot de passe : {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1535
+#: src/exif_turbo/ui/view_models/app_controller.py:1537
 #, python-brace-format
 msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
@@ -149,229 +149,246 @@ msgstr ""
 "Mot de passe modifié, mais le cache des miniatures n’a pas pu être "
 "rechiffré ({error}). Le cache a été effacé et sera reconstruit."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2376
+#: src/exif_turbo/ui/view_models/app_controller.py:2378
 msgid "Folder list reloaded."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2613
+#: src/exif_turbo/ui/view_models/app_controller.py:2615
 #, python-brace-format
 msgid "Folder already tracked: {}"
 msgstr "Dossier déjà suivi : {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2640
+#: src/exif_turbo/ui/view_models/app_controller.py:2642
 msgid "Removing folder…"
 msgstr "Suppression du dossier…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2812
+#: src/exif_turbo/ui/view_models/app_controller.py:2814
 msgid "Folder not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2818
+#: src/exif_turbo/ui/view_models/app_controller.py:2820
 #, python-brace-format
 msgid "Folder not accessible: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2857
+#: src/exif_turbo/ui/view_models/app_controller.py:2859
 #, python-brace-format
 msgid "Indexing {}…"
 msgstr "Indexation de {}…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2893
+#: src/exif_turbo/ui/view_models/app_controller.py:2895
 #, python-brace-format
 msgid "Indexed {count} images ({errors} skipped due to errors)"
 msgstr "{count} images indexées ({errors} ignorées en raison d’erreurs)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2898
+#: src/exif_turbo/ui/view_models/app_controller.py:2900
 #, python-brace-format
 msgid "Indexed {} images"
 msgstr "{} images indexées"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2931
+#: src/exif_turbo/ui/view_models/app_controller.py:2933
 #, python-brace-format
 msgid "Index failed: {}"
 msgstr "Indexation échouée : {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2963
+#: src/exif_turbo/ui/view_models/app_controller.py:2965
 msgid "Index canceled"
 msgstr "Indexation annulée"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2983
+#: src/exif_turbo/ui/view_models/app_controller.py:2985
 msgid "Canceling…"
 msgstr "Annulation…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3181
+#: src/exif_turbo/ui/view_models/app_controller.py:3183
 #, python-brace-format
 msgid "AI full rescan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3183
+#: src/exif_turbo/ui/view_models/app_controller.py:3185
 #, python-brace-format
 msgid "AI-Scan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3185
+#: src/exif_turbo/ui/view_models/app_controller.py:3187
 #, python-brace-format
 msgid "{n} file(s) could not be processed."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3192
+#: src/exif_turbo/ui/view_models/app_controller.py:3194
 #, python-brace-format
 msgid "AI full rescan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3194
+#: src/exif_turbo/ui/view_models/app_controller.py:3196
 #, python-brace-format
 msgid "AI-Scan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3201
+#: src/exif_turbo/ui/view_models/app_controller.py:3203
 #, python-brace-format
 msgid "AI full rescan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3205
+#: src/exif_turbo/ui/view_models/app_controller.py:3207
 #, python-brace-format
 msgid "AI-Scan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3231
+#: src/exif_turbo/ui/view_models/app_controller.py:3233
 #, python-brace-format
 msgid "Built {built} preview(s) of {total}."
 msgstr "{built} aperçu(s) créé(s) sur {total}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3235
+#: src/exif_turbo/ui/view_models/app_controller.py:3237
 #, python-brace-format
 msgid "{n} image(s) skipped — too large to decode safely."
 msgstr ""
 "{n} image(s) ignorée(s) — trop volumineuse(s) pour être décodée(s) sans "
 "risque."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3245
+#: src/exif_turbo/ui/view_models/app_controller.py:3247
 #, python-brace-format
 msgid "Preview build failed: {error}"
 msgstr "Création des aperçus échouée : {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3253
+#: src/exif_turbo/ui/view_models/app_controller.py:3255
 #, python-brace-format
 msgid "Preview build canceled ({built} of {total} done)."
 msgstr "Création des aperçus annulée ({built} sur {total} terminés)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3266
+#: src/exif_turbo/ui/view_models/app_controller.py:3268
 msgid "Cancel the running preview build before clearing the cache."
 msgstr "Annulez la création d’aperçus en cours avant de vider le cache."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3275
+#: src/exif_turbo/ui/view_models/app_controller.py:3277
 #, python-brace-format
 msgid "Failed to clear preview cache: {error}"
 msgstr "Échec du vidage du cache des aperçus : {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3281
+#: src/exif_turbo/ui/view_models/app_controller.py:3283
 #, python-brace-format
 msgid "Removed {n} cached preview(s)."
 msgstr "{n} aperçu(s) en cache supprimé(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3406
+#: src/exif_turbo/ui/view_models/app_controller.py:3408
 msgid "Image copied to clipboard"
 msgstr "Image copiée dans le presse-papiers"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3410
+#: src/exif_turbo/ui/view_models/app_controller.py:3412
 msgid "Path copied to clipboard"
 msgstr "Chemin copié dans le presse-papiers"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3423
+#: src/exif_turbo/ui/view_models/app_controller.py:3425
 msgid "Preview source file not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3430
+#: src/exif_turbo/ui/view_models/app_controller.py:3432
 msgid "Preview saved"
 msgstr "Prévisualisation enregistrée"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3442
-#: src/exif_turbo/ui/view_models/app_controller.py:3451
+#: src/exif_turbo/ui/view_models/app_controller.py:3444
+#: src/exif_turbo/ui/view_models/app_controller.py:3453
 msgid "File not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3447
+#: src/exif_turbo/ui/view_models/app_controller.py:3449
 msgid "Original saved"
 msgstr "Original enregistré"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3511
+#: src/exif_turbo/ui/view_models/app_controller.py:3513
 msgid "Resetting database…"
 msgstr "Réinitialisation de la base de données…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3536
+#: src/exif_turbo/ui/view_models/app_controller.py:3538
 msgid "Database reset"
 msgstr "Base de données réinitialisée"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3584
+#: src/exif_turbo/ui/view_models/app_controller.py:3586
 #, python-brace-format
 msgid "TGM source diagnostics: {}"
 msgstr "Diagnostics de la source TGM : {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3968
+#: src/exif_turbo/ui/view_models/app_controller.py:3949
+msgid "Choose whether to add or replace tags."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3960
+msgid "Choose a folder in Browse first."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3977
+msgid "Choose a valid copy target."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:4033
 #, python-brace-format
 msgid "Removed from {} image(s). Already absent: {}. Problems: {}."
 msgstr "Supprimé de {} image(s). Déjà absent : {}. Problèmes : {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3972
+#: src/exif_turbo/ui/view_models/app_controller.py:4037
+#, python-brace-format
+msgid "Copied tags to {} image(s). Unchanged: {}. Problems: {}."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:4041
 #, python-brace-format
 msgid "Added to {} image(s). Already tagged: {}. Problems: {}."
 msgstr "Ajouté à {} image(s). Déjà étiquetées : {}. Problèmes : {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3976
+#: src/exif_turbo/ui/view_models/app_controller.py:4045
 #, python-brace-format
 msgid "Canceled. {}"
 msgstr "Annulé. {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4068
+#: src/exif_turbo/ui/view_models/app_controller.py:4138
 #, python-brace-format
 msgid "Created derivative: {}"
 msgstr "Dérivé créé : {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4070
+#: src/exif_turbo/ui/view_models/app_controller.py:4140
 msgid "Created 1 derivative."
 msgstr "1 dérivé créé."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4074
+#: src/exif_turbo/ui/view_models/app_controller.py:4144
 #, python-brace-format
 msgid "Created {} derivatives in {}."
 msgstr "{} dérivés créés dans {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4079
+#: src/exif_turbo/ui/view_models/app_controller.py:4149
 #, python-brace-format
 msgid "Created {} derivatives."
 msgstr "{} dérivés créés."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4081
+#: src/exif_turbo/ui/view_models/app_controller.py:4151
 msgid "No derivatives were created."
 msgstr "Aucun dérivé n'a été créé."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4084
+#: src/exif_turbo/ui/view_models/app_controller.py:4154
 #, python-brace-format
 msgid "{} image(s) had no accepted tags."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4088
+#: src/exif_turbo/ui/view_models/app_controller.py:4158
 #, python-brace-format
 msgid "{} destination file(s) already existed."
 msgstr "{} fichier(s) de destination existaient déjà."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4091
+#: src/exif_turbo/ui/view_models/app_controller.py:4161
 #, python-brace-format
 msgid "{} derivative(s) failed."
 msgstr "{} dérivé(s) ont échoué."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4105
+#: src/exif_turbo/ui/view_models/app_controller.py:4175
 #, python-brace-format
 msgid "First failure ({}): {}"
 msgstr "Premier échec ({}): {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4108
+#: src/exif_turbo/ui/view_models/app_controller.py:4178
 #, python-brace-format
 msgid "{} derivative(s) canceled."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4240
+#: src/exif_turbo/ui/view_models/app_controller.py:4311
 #, python-brace-format
 msgid ""
 "Original data source not attached: {source} — attach or mount this folder"
@@ -380,26 +397,26 @@ msgstr ""
 "Source de données d'origine non rattachée : {source} — rattachez ou "
 "montez ce dossier pour ouvrir les fichiers."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4247
+#: src/exif_turbo/ui/view_models/app_controller.py:4318
 #, python-brace-format
 msgid "File not found: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4402
+#: src/exif_turbo/ui/view_models/app_controller.py:4473
 msgid "Cleaning up cache…"
 msgstr "Nettoyage du cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4422
+#: src/exif_turbo/ui/view_models/app_controller.py:4493
 #, python-brace-format
 msgid "Indexing… {} (scanning)"
 msgstr "Indexation… {} (analyse)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4424
+#: src/exif_turbo/ui/view_models/app_controller.py:4495
 #, python-brace-format
 msgid "Indexing… 0 / {}"
 msgstr "Indexation… 0 / {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4426
+#: src/exif_turbo/ui/view_models/app_controller.py:4497
 #, python-brace-format
 msgid "Indexing… {} / {}"
 msgstr "Indexation… {} / {}"
@@ -534,6 +551,12 @@ msgstr "Tout"
 #: QML
 msgid "All %1 previews are cached"
 msgstr "Tous les %1 aperçus sont en cache"
+
+#: QML
+msgid ""
+"All accepted and custom tags on each target image will be replaced. This "
+"cannot be undone."
+msgstr ""
 
 #: QML
 msgid "All files (*)"
@@ -679,6 +702,10 @@ msgid ""
 msgstr ""
 
 #: QML
+msgid "Copies accepted and custom tags. The current image is excluded."
+msgstr ""
+
+#: QML
 msgid "Copy"
 msgstr "Copier"
 
@@ -687,8 +714,20 @@ msgid "Copy Image to Clipboard"
 msgstr "Copier l’image dans le presse-papiers"
 
 #: QML
+msgid "Copy Tags"
+msgstr ""
+
+#: QML
 msgid "Copy preview image to clipboard"
 msgstr "Copier l’aperçu dans le presse-papiers"
+
+#: QML
+msgid "Copy tags to other images"
+msgstr ""
+
+#: QML
+msgid "Copying tags"
+msgstr ""
 
 #: QML
 msgid "Create Database"
@@ -707,8 +746,16 @@ msgstr ""
 "et d’indexation de métadonnées EXIF."
 
 #: QML
+msgid "Current folder (%1)"
+msgstr ""
+
+#: QML
 msgid "Current password"
 msgstr "Mot de passe actuel"
+
+#: QML
+msgid "Current search results (%1)"
+msgstr ""
 
 #: QML
 msgid "Custom tags"
@@ -1047,6 +1094,10 @@ msgid "Jump to this image in the Browse tab"
 msgstr ""
 
 #: QML
+msgid "Keep target tags and add missing source tags"
+msgstr ""
+
+#: QML
 msgid "Language"
 msgstr "Langue"
 
@@ -1079,6 +1130,10 @@ msgstr "MÉTADONNÉES"
 #: QML
 msgid "Managed Folders"
 msgstr "Dossiers gérés"
+
+#: QML
+msgid "Marked images (%1)"
+msgstr "Images marquées (%1)"
 
 #: QML
 msgid "Meaning"
@@ -1322,6 +1377,10 @@ msgid "Remove from selected image"
 msgstr "Supprimer de l’image sélectionnée"
 
 #: QML
+msgid "Remove target tags before copying source tags"
+msgstr ""
+
+#: QML
 msgid "Remove this folder and delete its indexed images"
 msgstr "Supprimer ce dossier et ses images indexées"
 
@@ -1337,6 +1396,14 @@ msgstr ""
 #: QML
 msgid "Render preview-cache JPEGs for this folder"
 msgstr "Générer les JPEG du cache d’aperçus pour ce dossier"
+
+#: QML
+msgid "Replace"
+msgstr ""
+
+#: QML
+msgid "Replace tags on target images?"
+msgstr ""
 
 #: QML
 msgid "Rescan"

--- a/src/exif_turbo/i18n/locales/it/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/it/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-14 16:48+0200\n"
+"POT-Creation-Date: 2026-08-17 20:45+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: it\n"
@@ -22,123 +22,123 @@ msgstr ""
 msgid "PyTorch is not available on macOS Intel for Python 3.13+."
 msgstr "PyTorch non è disponibile su macOS Intel per Python 3.13+."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:217
+#: src/exif_turbo/ui/view_models/app_controller.py:218
 msgid "Enter the database password to continue"
 msgstr "Inserisci la password del database per continuare"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:990
+#: src/exif_turbo/ui/view_models/app_controller.py:992
 msgid "Selecting all matching images…"
 msgstr "Selezione di tutte le immagini corrispondenti…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1000
+#: src/exif_turbo/ui/view_models/app_controller.py:1002
 msgid "Deselecting all matching images…"
 msgstr "Deselezione di tutte le immagini corrispondenti…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1010
+#: src/exif_turbo/ui/view_models/app_controller.py:1012
 msgid "Inverting selection…"
 msgstr "Inversione della selezione…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1024
+#: src/exif_turbo/ui/view_models/app_controller.py:1026
 msgid "Selecting images without a cached thumbnail…"
 msgstr "Selezione delle immagini senza miniatura nella cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1039
+#: src/exif_turbo/ui/view_models/app_controller.py:1041
 msgid "No marked images to delete."
 msgstr "Nessuna immagine contrassegnata da eliminare."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1043
+#: src/exif_turbo/ui/view_models/app_controller.py:1045
 msgid "Deleting marked images…"
 msgstr "Eliminazione delle immagini contrassegnate…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1053
+#: src/exif_turbo/ui/view_models/app_controller.py:1055
 msgid "No marked images to export."
 msgstr "Nessuna immagine contrassegnata da esportare."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1058
+#: src/exif_turbo/ui/view_models/app_controller.py:1060
 msgid "Exporting metadata…"
 msgstr "Esportazione metadati…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1160
+#: src/exif_turbo/ui/view_models/app_controller.py:1162
 #, python-brace-format
 msgid "Deleted {n} image(s)."
 msgstr "{n} immagine/i eliminata/e."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1164
+#: src/exif_turbo/ui/view_models/app_controller.py:1166
 #, python-brace-format
 msgid "{n} were already missing."
 msgstr "{n} erano già mancanti."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1170
+#: src/exif_turbo/ui/view_models/app_controller.py:1172
 #, python-brace-format
 msgid "{n} could not be deleted."
 msgstr "{n} non è/sono potuta/e essere eliminata/e."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1180
+#: src/exif_turbo/ui/view_models/app_controller.py:1182
 #, python-brace-format
 msgid "Exported {count} image(s) to {name}"
 msgstr "{count} immagine/i esportata/e in {name}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1190
-#: src/exif_turbo/ui/view_models/app_controller.py:1272
+#: src/exif_turbo/ui/view_models/app_controller.py:1192
+#: src/exif_turbo/ui/view_models/app_controller.py:1274
 #, python-brace-format
 msgid "Operation failed: {}"
 msgstr "Operazione fallita: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1196
-#: src/exif_turbo/ui/view_models/app_controller.py:1278
+#: src/exif_turbo/ui/view_models/app_controller.py:1198
+#: src/exif_turbo/ui/view_models/app_controller.py:1280
 msgid "Operation canceled."
 msgstr "Operazione annullata."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1366
+#: src/exif_turbo/ui/view_models/app_controller.py:1368
 msgid "Wrong password — please try again."
 msgstr "Password errata — riprova."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1378
+#: src/exif_turbo/ui/view_models/app_controller.py:1380
 #, python-brace-format
 msgid "Failed to open database: {error}"
 msgstr "Impossibile aprire il database: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1404
+#: src/exif_turbo/ui/view_models/app_controller.py:1406
 msgid "Database is locked."
 msgstr "Il database è bloccato."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1409
+#: src/exif_turbo/ui/view_models/app_controller.py:1411
 msgid "Cannot change password while indexing or thumb-building is running."
 msgstr ""
 "Impossibile cambiare la password mentre è in corso l’indicizzazione o la "
 "creazione delle miniature."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1413
+#: src/exif_turbo/ui/view_models/app_controller.py:1415
 msgid "Current password is incorrect."
 msgstr "La password attuale non è corretta."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1416
+#: src/exif_turbo/ui/view_models/app_controller.py:1418
 msgid "New password must not be empty."
 msgstr "La nuova password non può essere vuota."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1420
+#: src/exif_turbo/ui/view_models/app_controller.py:1422
 msgid "New password must differ from the current password."
 msgstr "La nuova password deve essere diversa da quella attuale."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1438
+#: src/exif_turbo/ui/view_models/app_controller.py:1440
 msgid "Changing password…"
 msgstr "Modifica password in corso…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1479
+#: src/exif_turbo/ui/view_models/app_controller.py:1481
 #, python-brace-format
 msgid "Database password changed, but reopening failed: {error}"
 msgstr "Password del database modificata, ma la riapertura non è riuscita: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1489
+#: src/exif_turbo/ui/view_models/app_controller.py:1491
 msgid "Password changed successfully."
 msgstr "Password modificata correttamente."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1530
+#: src/exif_turbo/ui/view_models/app_controller.py:1532
 #, python-brace-format
 msgid "Failed to change password: {error}"
 msgstr "Modifica password non riuscita: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1535
+#: src/exif_turbo/ui/view_models/app_controller.py:1537
 #, python-brace-format
 msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
@@ -147,229 +147,246 @@ msgstr ""
 "La password è stata modificata ma la cache delle miniature non è stata "
 "ricifrata ({error}). La cache è stata svuotata e verrà ricostruita."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2376
+#: src/exif_turbo/ui/view_models/app_controller.py:2378
 msgid "Folder list reloaded."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2613
+#: src/exif_turbo/ui/view_models/app_controller.py:2615
 #, python-brace-format
 msgid "Folder already tracked: {}"
 msgstr "Cartella già monitorata: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2640
+#: src/exif_turbo/ui/view_models/app_controller.py:2642
 msgid "Removing folder…"
 msgstr "Rimozione della cartella…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2812
+#: src/exif_turbo/ui/view_models/app_controller.py:2814
 msgid "Folder not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2818
+#: src/exif_turbo/ui/view_models/app_controller.py:2820
 #, python-brace-format
 msgid "Folder not accessible: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2857
+#: src/exif_turbo/ui/view_models/app_controller.py:2859
 #, python-brace-format
 msgid "Indexing {}…"
 msgstr "Indicizzazione {}…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2893
+#: src/exif_turbo/ui/view_models/app_controller.py:2895
 #, python-brace-format
 msgid "Indexed {count} images ({errors} skipped due to errors)"
 msgstr "{count} immagini indicizzate ({errors} saltate a causa di errori)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2898
+#: src/exif_turbo/ui/view_models/app_controller.py:2900
 #, python-brace-format
 msgid "Indexed {} images"
 msgstr "{} immagini indicizzate"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2931
+#: src/exif_turbo/ui/view_models/app_controller.py:2933
 #, python-brace-format
 msgid "Index failed: {}"
 msgstr "Indicizzazione fallita: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2963
+#: src/exif_turbo/ui/view_models/app_controller.py:2965
 msgid "Index canceled"
 msgstr "Indicizzazione annullata"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2983
+#: src/exif_turbo/ui/view_models/app_controller.py:2985
 msgid "Canceling…"
 msgstr "Annullamento…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3181
+#: src/exif_turbo/ui/view_models/app_controller.py:3183
 #, python-brace-format
 msgid "AI full rescan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3183
+#: src/exif_turbo/ui/view_models/app_controller.py:3185
 #, python-brace-format
 msgid "AI-Scan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3185
+#: src/exif_turbo/ui/view_models/app_controller.py:3187
 #, python-brace-format
 msgid "{n} file(s) could not be processed."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3192
+#: src/exif_turbo/ui/view_models/app_controller.py:3194
 #, python-brace-format
 msgid "AI full rescan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3194
+#: src/exif_turbo/ui/view_models/app_controller.py:3196
 #, python-brace-format
 msgid "AI-Scan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3201
+#: src/exif_turbo/ui/view_models/app_controller.py:3203
 #, python-brace-format
 msgid "AI full rescan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3205
+#: src/exif_turbo/ui/view_models/app_controller.py:3207
 #, python-brace-format
 msgid "AI-Scan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3231
+#: src/exif_turbo/ui/view_models/app_controller.py:3233
 #, python-brace-format
 msgid "Built {built} preview(s) of {total}."
 msgstr "{built} anteprima/e create di {total}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3235
+#: src/exif_turbo/ui/view_models/app_controller.py:3237
 #, python-brace-format
 msgid "{n} image(s) skipped — too large to decode safely."
 msgstr ""
 "{n} immagine/i saltata/e — troppo grande/i per essere decodificata/e in "
 "sicurezza."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3245
+#: src/exif_turbo/ui/view_models/app_controller.py:3247
 #, python-brace-format
 msgid "Preview build failed: {error}"
 msgstr "Creazione anteprime non riuscita: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3253
+#: src/exif_turbo/ui/view_models/app_controller.py:3255
 #, python-brace-format
 msgid "Preview build canceled ({built} of {total} done)."
 msgstr "Creazione anteprime annullata ({built} di {total} completate)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3266
+#: src/exif_turbo/ui/view_models/app_controller.py:3268
 msgid "Cancel the running preview build before clearing the cache."
 msgstr "Annulla la creazione delle anteprime in corso prima di svuotare la cache."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3275
+#: src/exif_turbo/ui/view_models/app_controller.py:3277
 #, python-brace-format
 msgid "Failed to clear preview cache: {error}"
 msgstr "Impossibile svuotare la cache delle anteprime: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3281
+#: src/exif_turbo/ui/view_models/app_controller.py:3283
 #, python-brace-format
 msgid "Removed {n} cached preview(s)."
 msgstr "{n} anteprima/e in cache rimossa/e."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3406
+#: src/exif_turbo/ui/view_models/app_controller.py:3408
 msgid "Image copied to clipboard"
 msgstr "Immagine copiata negli appunti"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3410
+#: src/exif_turbo/ui/view_models/app_controller.py:3412
 msgid "Path copied to clipboard"
 msgstr "Percorso copiato negli appunti"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3423
+#: src/exif_turbo/ui/view_models/app_controller.py:3425
 msgid "Preview source file not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3430
+#: src/exif_turbo/ui/view_models/app_controller.py:3432
 msgid "Preview saved"
 msgstr "Anteprima salvata"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3442
-#: src/exif_turbo/ui/view_models/app_controller.py:3451
+#: src/exif_turbo/ui/view_models/app_controller.py:3444
+#: src/exif_turbo/ui/view_models/app_controller.py:3453
 msgid "File not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3447
+#: src/exif_turbo/ui/view_models/app_controller.py:3449
 msgid "Original saved"
 msgstr "Originale salvato"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3511
+#: src/exif_turbo/ui/view_models/app_controller.py:3513
 msgid "Resetting database…"
 msgstr "Ripristino del database…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3536
+#: src/exif_turbo/ui/view_models/app_controller.py:3538
 msgid "Database reset"
 msgstr "Database ripristinato"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3584
+#: src/exif_turbo/ui/view_models/app_controller.py:3586
 #, python-brace-format
 msgid "TGM source diagnostics: {}"
 msgstr "Diagnostica della fonte TGM: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3968
+#: src/exif_turbo/ui/view_models/app_controller.py:3949
+msgid "Choose whether to add or replace tags."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3960
+msgid "Choose a folder in Browse first."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3977
+msgid "Choose a valid copy target."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:4033
 #, python-brace-format
 msgid "Removed from {} image(s). Already absent: {}. Problems: {}."
 msgstr "Rimosso da {} immagine/i. Già assente: {}. Problemi: {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3972
+#: src/exif_turbo/ui/view_models/app_controller.py:4037
+#, python-brace-format
+msgid "Copied tags to {} image(s). Unchanged: {}. Problems: {}."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:4041
 #, python-brace-format
 msgid "Added to {} image(s). Already tagged: {}. Problems: {}."
 msgstr "Aggiunto a {} immagine/i. Già con tag: {}. Problemi: {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3976
+#: src/exif_turbo/ui/view_models/app_controller.py:4045
 #, python-brace-format
 msgid "Canceled. {}"
 msgstr "Annullato. {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4068
+#: src/exif_turbo/ui/view_models/app_controller.py:4138
 #, python-brace-format
 msgid "Created derivative: {}"
 msgstr "Derivato creato: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4070
+#: src/exif_turbo/ui/view_models/app_controller.py:4140
 msgid "Created 1 derivative."
 msgstr "Creato 1 derivato."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4074
+#: src/exif_turbo/ui/view_models/app_controller.py:4144
 #, python-brace-format
 msgid "Created {} derivatives in {}."
 msgstr "Creati {} derivati in {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4079
+#: src/exif_turbo/ui/view_models/app_controller.py:4149
 #, python-brace-format
 msgid "Created {} derivatives."
 msgstr "Creati {} derivati."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4081
+#: src/exif_turbo/ui/view_models/app_controller.py:4151
 msgid "No derivatives were created."
 msgstr "Non è stato creato alcun derivato."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4084
+#: src/exif_turbo/ui/view_models/app_controller.py:4154
 #, python-brace-format
 msgid "{} image(s) had no accepted tags."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4088
+#: src/exif_turbo/ui/view_models/app_controller.py:4158
 #, python-brace-format
 msgid "{} destination file(s) already existed."
 msgstr "{} file di destinazione esisteva/no già."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4091
+#: src/exif_turbo/ui/view_models/app_controller.py:4161
 #, python-brace-format
 msgid "{} derivative(s) failed."
 msgstr "{} derivato/i non riuscito/i."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4105
+#: src/exif_turbo/ui/view_models/app_controller.py:4175
 #, python-brace-format
 msgid "First failure ({}): {}"
 msgstr "Primo errore ({}): {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4108
+#: src/exif_turbo/ui/view_models/app_controller.py:4178
 #, python-brace-format
 msgid "{} derivative(s) canceled."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4240
+#: src/exif_turbo/ui/view_models/app_controller.py:4311
 #, python-brace-format
 msgid ""
 "Original data source not attached: {source} — attach or mount this folder"
@@ -378,26 +395,26 @@ msgstr ""
 "Origine dati originale non collegata: {source} — collega o monta questa "
 "cartella per aprire i file."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4247
+#: src/exif_turbo/ui/view_models/app_controller.py:4318
 #, python-brace-format
 msgid "File not found: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4402
+#: src/exif_turbo/ui/view_models/app_controller.py:4473
 msgid "Cleaning up cache…"
 msgstr "Pulizia della cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4422
+#: src/exif_turbo/ui/view_models/app_controller.py:4493
 #, python-brace-format
 msgid "Indexing… {} (scanning)"
 msgstr "Indicizzazione… {} (scansione)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4424
+#: src/exif_turbo/ui/view_models/app_controller.py:4495
 #, python-brace-format
 msgid "Indexing… 0 / {}"
 msgstr "Indicizzazione… 0 / {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4426
+#: src/exif_turbo/ui/view_models/app_controller.py:4497
 #, python-brace-format
 msgid "Indexing… {} / {}"
 msgstr "Indicizzazione… {} / {}"
@@ -532,6 +549,12 @@ msgstr "Tutti"
 #: QML
 msgid "All %1 previews are cached"
 msgstr "Tutte le %1 anteprime sono in cache"
+
+#: QML
+msgid ""
+"All accepted and custom tags on each target image will be replaced. This "
+"cannot be undone."
+msgstr ""
 
 #: QML
 msgid "All files (*)"
@@ -677,6 +700,10 @@ msgid ""
 msgstr ""
 
 #: QML
+msgid "Copies accepted and custom tags. The current image is excluded."
+msgstr ""
+
+#: QML
 msgid "Copy"
 msgstr "Copia"
 
@@ -685,8 +712,20 @@ msgid "Copy Image to Clipboard"
 msgstr "Copia immagine negli appunti"
 
 #: QML
+msgid "Copy Tags"
+msgstr ""
+
+#: QML
 msgid "Copy preview image to clipboard"
 msgstr "Copia anteprima negli appunti"
+
+#: QML
+msgid "Copy tags to other images"
+msgstr ""
+
+#: QML
+msgid "Copying tags"
+msgstr ""
 
 #: QML
 msgid "Create Database"
@@ -705,8 +744,16 @@ msgstr ""
 "e l’indicizzazione di metadati EXIF."
 
 #: QML
+msgid "Current folder (%1)"
+msgstr ""
+
+#: QML
 msgid "Current password"
 msgstr "Password attuale"
+
+#: QML
+msgid "Current search results (%1)"
+msgstr ""
 
 #: QML
 msgid "Custom tags"
@@ -1043,6 +1090,10 @@ msgid "Jump to this image in the Browse tab"
 msgstr ""
 
 #: QML
+msgid "Keep target tags and add missing source tags"
+msgstr ""
+
+#: QML
 msgid "Language"
 msgstr "Lingua"
 
@@ -1075,6 +1126,10 @@ msgstr "METADATI"
 #: QML
 msgid "Managed Folders"
 msgstr "Cartelle gestite"
+
+#: QML
+msgid "Marked images (%1)"
+msgstr "Immagini contrassegnate (%1)"
 
 #: QML
 msgid "Meaning"
@@ -1320,6 +1375,10 @@ msgid "Remove from selected image"
 msgstr "Rimuovi dall’immagine selezionata"
 
 #: QML
+msgid "Remove target tags before copying source tags"
+msgstr ""
+
+#: QML
 msgid "Remove this folder and delete its indexed images"
 msgstr "Rimuovi questa cartella ed elimina le sue immagini indicizzate"
 
@@ -1335,6 +1394,14 @@ msgstr ""
 #: QML
 msgid "Render preview-cache JPEGs for this folder"
 msgstr "Genera JPEG della cache anteprime per questa cartella"
+
+#: QML
+msgid "Replace"
+msgstr ""
+
+#: QML
+msgid "Replace tags on target images?"
+msgstr ""
 
 #: QML
 msgid "Rescan"

--- a/src/exif_turbo/i18n/locales/rm/LC_MESSAGES/exif_turbo.po
+++ b/src/exif_turbo/i18n/locales/rm/LC_MESSAGES/exif_turbo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2026-08-14 16:48+0200\n"
+"POT-Creation-Date: 2026-08-17 20:45+0200\n"
 "PO-Revision-Date: 2026-04-25 17:34+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: rm\n"
@@ -22,125 +22,125 @@ msgstr ""
 msgid "PyTorch is not available on macOS Intel for Python 3.13+."
 msgstr "PyTorch na è betg disponibel sin macOS Intel per Python 3.13+."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:217
+#: src/exif_turbo/ui/view_models/app_controller.py:218
 msgid "Enter the database password to continue"
 msgstr "Endatar la pled-clav da la banca da datas per cuntinuar"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:990
+#: src/exif_turbo/ui/view_models/app_controller.py:992
 msgid "Selecting all matching images…"
 msgstr "Seleziun da tuts ils maletgs correspundentas…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1000
+#: src/exif_turbo/ui/view_models/app_controller.py:1002
 msgid "Deselecting all matching images…"
 msgstr "Deseleziun da tuts ils maletgs correspundentas…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1010
+#: src/exif_turbo/ui/view_models/app_controller.py:1012
 msgid "Inverting selection…"
 msgstr "Inversiun da la selecziun…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1024
+#: src/exif_turbo/ui/view_models/app_controller.py:1026
 msgid "Selecting images without a cached thumbnail…"
 msgstr "Seleziun da maletgs senza miniatura en il cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1039
+#: src/exif_turbo/ui/view_models/app_controller.py:1041
 msgid "No marked images to delete."
 msgstr "Nagins maletgs marcads per stizzar."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1043
+#: src/exif_turbo/ui/view_models/app_controller.py:1045
 msgid "Deleting marked images…"
 msgstr "Maletgs marcads vegnan stizzads…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1053
+#: src/exif_turbo/ui/view_models/app_controller.py:1055
 msgid "No marked images to export."
 msgstr "Nagins maletgs marcads per exportar."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1058
+#: src/exif_turbo/ui/view_models/app_controller.py:1060
 msgid "Exporting metadata…"
 msgstr "Exportaziun da metadata…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1160
+#: src/exif_turbo/ui/view_models/app_controller.py:1162
 #, python-brace-format
 msgid "Deleted {n} image(s)."
 msgstr "{n} maletg(s) stizzad(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1164
+#: src/exif_turbo/ui/view_models/app_controller.py:1166
 #, python-brace-format
 msgid "{n} were already missing."
 msgstr "{n} eran gia betg chattabels."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1170
+#: src/exif_turbo/ui/view_models/app_controller.py:1172
 #, python-brace-format
 msgid "{n} could not be deleted."
 msgstr "{n} n’han betg pudì vegnir stizzads."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1180
+#: src/exif_turbo/ui/view_models/app_controller.py:1182
 #, python-brace-format
 msgid "Exported {count} image(s) to {name}"
 msgstr "{count} maletg(s) exportad(s) en {name}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1190
-#: src/exif_turbo/ui/view_models/app_controller.py:1272
+#: src/exif_turbo/ui/view_models/app_controller.py:1192
+#: src/exif_turbo/ui/view_models/app_controller.py:1274
 #, python-brace-format
 msgid "Operation failed: {}"
 msgstr "Operaziun buca reussida: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1196
-#: src/exif_turbo/ui/view_models/app_controller.py:1278
+#: src/exif_turbo/ui/view_models/app_controller.py:1198
+#: src/exif_turbo/ui/view_models/app_controller.py:1280
 msgid "Operation canceled."
 msgstr "Operaziun annullada."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1366
+#: src/exif_turbo/ui/view_models/app_controller.py:1368
 msgid "Wrong password — please try again."
 msgstr "Pled-clav fauss — emprova p.pl. anc ina giada."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1378
+#: src/exif_turbo/ui/view_models/app_controller.py:1380
 #, python-brace-format
 msgid "Failed to open database: {error}"
 msgstr "Impussibel da rir la banca da datas: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1404
+#: src/exif_turbo/ui/view_models/app_controller.py:1406
 msgid "Database is locked."
 msgstr "La banca da datas è serrada."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1409
+#: src/exif_turbo/ui/view_models/app_controller.py:1411
 msgid "Cannot change password while indexing or thumb-building is running."
 msgstr ""
 "Impussibel da midar la pled-clav durant l’indexaziun u la creaziun da "
 "miniaturas."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1413
+#: src/exif_turbo/ui/view_models/app_controller.py:1415
 msgid "Current password is incorrect."
 msgstr "La pled-clav actuala n’è betg correcta."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1416
+#: src/exif_turbo/ui/view_models/app_controller.py:1418
 msgid "New password must not be empty."
 msgstr "La nova pled-clav na dastga betg esser vida."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1420
+#: src/exif_turbo/ui/view_models/app_controller.py:1422
 msgid "New password must differ from the current password."
 msgstr "La nova pled-clav sto esser differenta da quella actuala."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1438
+#: src/exif_turbo/ui/view_models/app_controller.py:1440
 msgid "Changing password…"
 msgstr "Pled-clav vegn midada…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1479
+#: src/exif_turbo/ui/view_models/app_controller.py:1481
 #, python-brace-format
 msgid "Database password changed, but reopening failed: {error}"
 msgstr ""
 "La pled-clav da la banca da datas è vegnida midada, ma la reaviertura n’è"
 " betg reussida: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1489
+#: src/exif_turbo/ui/view_models/app_controller.py:1491
 msgid "Password changed successfully."
 msgstr "Pled-clav midada cun success."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1530
+#: src/exif_turbo/ui/view_models/app_controller.py:1532
 #, python-brace-format
 msgid "Failed to change password: {error}"
 msgstr "Midada da la pled-clav betg reussida: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:1535
+#: src/exif_turbo/ui/view_models/app_controller.py:1537
 #, python-brace-format
 msgid ""
 "Password changed but thumbnail cache could not be re-wrapped ({error}). "
@@ -149,227 +149,244 @@ msgstr ""
 "La pled-clav è vegnida midada, ma il cache da miniaturas n’è betg pudida "
 "vegnir cifrada da nov ({error}). Il cache è vegnì stizzad e vegn rebatgì."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2376
+#: src/exif_turbo/ui/view_models/app_controller.py:2378
 msgid "Folder list reloaded."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2613
+#: src/exif_turbo/ui/view_models/app_controller.py:2615
 #, python-brace-format
 msgid "Folder already tracked: {}"
 msgstr "Cartella gia trackata: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2640
+#: src/exif_turbo/ui/view_models/app_controller.py:2642
 msgid "Removing folder…"
 msgstr "Allontanar la cartella…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2812
+#: src/exif_turbo/ui/view_models/app_controller.py:2814
 msgid "Folder not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2818
+#: src/exif_turbo/ui/view_models/app_controller.py:2820
 #, python-brace-format
 msgid "Folder not accessible: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2857
+#: src/exif_turbo/ui/view_models/app_controller.py:2859
 #, python-brace-format
 msgid "Indexing {}…"
 msgstr "Indexaziun {}…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2893
+#: src/exif_turbo/ui/view_models/app_controller.py:2895
 #, python-brace-format
 msgid "Indexed {count} images ({errors} skipped due to errors)"
 msgstr "{count} maletgs indexads ({errors} sursiglids pervia d’errurs)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2898
+#: src/exif_turbo/ui/view_models/app_controller.py:2900
 #, python-brace-format
 msgid "Indexed {} images"
 msgstr "{} maletgs indexads"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2931
+#: src/exif_turbo/ui/view_models/app_controller.py:2933
 #, python-brace-format
 msgid "Index failed: {}"
 msgstr "Indexaziun buca reussida: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2963
+#: src/exif_turbo/ui/view_models/app_controller.py:2965
 msgid "Index canceled"
 msgstr "Indexaziun interrutta"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:2983
+#: src/exif_turbo/ui/view_models/app_controller.py:2985
 msgid "Canceling…"
 msgstr "Interruziun…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3181
+#: src/exif_turbo/ui/view_models/app_controller.py:3183
 #, python-brace-format
 msgid "AI full rescan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3183
+#: src/exif_turbo/ui/view_models/app_controller.py:3185
 #, python-brace-format
 msgid "AI-Scan complete: {n} image(s) vectorised."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3185
+#: src/exif_turbo/ui/view_models/app_controller.py:3187
 #, python-brace-format
 msgid "{n} file(s) could not be processed."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3192
+#: src/exif_turbo/ui/view_models/app_controller.py:3194
 #, python-brace-format
 msgid "AI full rescan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3194
+#: src/exif_turbo/ui/view_models/app_controller.py:3196
 #, python-brace-format
 msgid "AI-Scan failed: {error}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3201
+#: src/exif_turbo/ui/view_models/app_controller.py:3203
 #, python-brace-format
 msgid "AI full rescan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3205
+#: src/exif_turbo/ui/view_models/app_controller.py:3207
 #, python-brace-format
 msgid "AI-Scan canceled ({n} image(s) vectorised so far)."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3231
+#: src/exif_turbo/ui/view_models/app_controller.py:3233
 #, python-brace-format
 msgid "Built {built} preview(s) of {total}."
 msgstr "{built} prevista(s) da {total} creada(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3235
+#: src/exif_turbo/ui/view_models/app_controller.py:3237
 #, python-brace-format
 msgid "{n} image(s) skipped — too large to decode safely."
 msgstr "{n} maletg(s) sursiglid(s) — memia gronds per decodar senza riscu."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3245
+#: src/exif_turbo/ui/view_models/app_controller.py:3247
 #, python-brace-format
 msgid "Preview build failed: {error}"
 msgstr "Creaziun da previstas buca reussida: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3253
+#: src/exif_turbo/ui/view_models/app_controller.py:3255
 #, python-brace-format
 msgid "Preview build canceled ({built} of {total} done)."
 msgstr "Creaziun da previstas interrutta ({built} da {total} fatg)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3266
+#: src/exif_turbo/ui/view_models/app_controller.py:3268
 msgid "Cancel the running preview build before clearing the cache."
 msgstr "Interrumper la creaziun da previstas en cors avant da stizzar il cache."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3275
+#: src/exif_turbo/ui/view_models/app_controller.py:3277
 #, python-brace-format
 msgid "Failed to clear preview cache: {error}"
 msgstr "Stizzar il cache da previstas n’è betg reussì: {error}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3281
+#: src/exif_turbo/ui/view_models/app_controller.py:3283
 #, python-brace-format
 msgid "Removed {n} cached preview(s)."
 msgstr "{n} prevista(s) dal cache vegnida(s) stizzada(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3406
+#: src/exif_turbo/ui/view_models/app_controller.py:3408
 msgid "Image copied to clipboard"
 msgstr "Maletg copià en la tavla d’interscambi"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3410
+#: src/exif_turbo/ui/view_models/app_controller.py:3412
 msgid "Path copied to clipboard"
 msgstr "Traject copià en la tavla d’interscambi"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3423
+#: src/exif_turbo/ui/view_models/app_controller.py:3425
 msgid "Preview source file not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3430
+#: src/exif_turbo/ui/view_models/app_controller.py:3432
 msgid "Preview saved"
 msgstr "Prevista memorisada"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3442
-#: src/exif_turbo/ui/view_models/app_controller.py:3451
+#: src/exif_turbo/ui/view_models/app_controller.py:3444
+#: src/exif_turbo/ui/view_models/app_controller.py:3453
 msgid "File not accessible"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3447
+#: src/exif_turbo/ui/view_models/app_controller.py:3449
 msgid "Original saved"
 msgstr "Original memorisà"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3511
+#: src/exif_turbo/ui/view_models/app_controller.py:3513
 msgid "Resetting database…"
 msgstr "Reinizialisar la banca da datas…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3536
+#: src/exif_turbo/ui/view_models/app_controller.py:3538
 msgid "Database reset"
 msgstr "Banca da datas resettada"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3584
+#: src/exif_turbo/ui/view_models/app_controller.py:3586
 #, python-brace-format
 msgid "TGM source diagnostics: {}"
 msgstr "Diagnostica da la funtauna TGM: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3968
+#: src/exif_turbo/ui/view_models/app_controller.py:3949
+msgid "Choose whether to add or replace tags."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3960
+msgid "Choose a folder in Browse first."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:3977
+msgid "Choose a valid copy target."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:4033
 #, python-brace-format
 msgid "Removed from {} image(s). Already absent: {}. Problems: {}."
 msgstr "Allontanà da {} maletg(s). Gia absent: {}. Problems: {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3972
+#: src/exif_turbo/ui/view_models/app_controller.py:4037
+#, python-brace-format
+msgid "Copied tags to {} image(s). Unchanged: {}. Problems: {}."
+msgstr ""
+
+#: src/exif_turbo/ui/view_models/app_controller.py:4041
 #, python-brace-format
 msgid "Added to {} image(s). Already tagged: {}. Problems: {}."
 msgstr "Agiuntà a {} maletg(s). Gia chavazzinà: {}. Problems: {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:3976
+#: src/exif_turbo/ui/view_models/app_controller.py:4045
 #, python-brace-format
 msgid "Canceled. {}"
 msgstr "Interrut. {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4068
+#: src/exif_turbo/ui/view_models/app_controller.py:4138
 #, python-brace-format
 msgid "Created derivative: {}"
 msgstr "Derivat creà: {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4070
+#: src/exif_turbo/ui/view_models/app_controller.py:4140
 msgid "Created 1 derivative."
 msgstr "1 derivat creà."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4074
+#: src/exif_turbo/ui/view_models/app_controller.py:4144
 #, python-brace-format
 msgid "Created {} derivatives in {}."
 msgstr "{} derivats creads en {}."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4079
+#: src/exif_turbo/ui/view_models/app_controller.py:4149
 #, python-brace-format
 msgid "Created {} derivatives."
 msgstr "{} derivats creads."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4081
+#: src/exif_turbo/ui/view_models/app_controller.py:4151
 msgid "No derivatives were created."
 msgstr "Nagins derivats èn vegnids creads."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4084
+#: src/exif_turbo/ui/view_models/app_controller.py:4154
 #, python-brace-format
 msgid "{} image(s) had no accepted tags."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4088
+#: src/exif_turbo/ui/view_models/app_controller.py:4158
 #, python-brace-format
 msgid "{} destination file(s) already existed."
 msgstr "{} datoteca(s) da destinaziun existiva(n) gia."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4091
+#: src/exif_turbo/ui/view_models/app_controller.py:4161
 #, python-brace-format
 msgid "{} derivative(s) failed."
 msgstr "{} derivat(s) n'è(n) betg reussì(s)."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4105
+#: src/exif_turbo/ui/view_models/app_controller.py:4175
 #, python-brace-format
 msgid "First failure ({}): {}"
 msgstr "Emprim sbagl ({}): {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4108
+#: src/exif_turbo/ui/view_models/app_controller.py:4178
 #, python-brace-format
 msgid "{} derivative(s) canceled."
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4240
+#: src/exif_turbo/ui/view_models/app_controller.py:4311
 #, python-brace-format
 msgid ""
 "Original data source not attached: {source} — attach or mount this folder"
@@ -378,26 +395,26 @@ msgstr ""
 "Funtauna da datas originala betg colliada: {source} — colliai u montai "
 "questa cartella per avrir datotecas."
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4247
+#: src/exif_turbo/ui/view_models/app_controller.py:4318
 #, python-brace-format
 msgid "File not found: {}"
 msgstr ""
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4402
+#: src/exif_turbo/ui/view_models/app_controller.py:4473
 msgid "Cleaning up cache…"
 msgstr "Stizzar il cache…"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4422
+#: src/exif_turbo/ui/view_models/app_controller.py:4493
 #, python-brace-format
 msgid "Indexing… {} (scanning)"
 msgstr "Indexaziun… {} (tscherta)"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4424
+#: src/exif_turbo/ui/view_models/app_controller.py:4495
 #, python-brace-format
 msgid "Indexing… 0 / {}"
 msgstr "Indexaziun… 0 / {}"
 
-#: src/exif_turbo/ui/view_models/app_controller.py:4426
+#: src/exif_turbo/ui/view_models/app_controller.py:4497
 #, python-brace-format
 msgid "Indexing… {} / {}"
 msgstr "Indexaziun… {} / {}"
@@ -532,6 +549,12 @@ msgstr "Tuts"
 #: QML
 msgid "All %1 previews are cached"
 msgstr "Tut las %1 previstas èn en cache"
+
+#: QML
+msgid ""
+"All accepted and custom tags on each target image will be replaced. This "
+"cannot be undone."
+msgstr ""
 
 #: QML
 msgid "All files (*)"
@@ -677,6 +700,10 @@ msgid ""
 msgstr ""
 
 #: QML
+msgid "Copies accepted and custom tags. The current image is excluded."
+msgstr ""
+
+#: QML
 msgid "Copy"
 msgstr "Copiar"
 
@@ -685,8 +712,20 @@ msgid "Copy Image to Clipboard"
 msgstr "Copiar maletg en tavla d’interscambi"
 
 #: QML
+msgid "Copy Tags"
+msgstr ""
+
+#: QML
 msgid "Copy preview image to clipboard"
 msgstr "Copiar prevista en tavla d’interscambi"
+
+#: QML
+msgid "Copy tags to other images"
+msgstr ""
+
+#: QML
+msgid "Copying tags"
+msgstr ""
 
 #: QML
 msgid "Create Database"
@@ -705,8 +744,16 @@ msgstr ""
 "e indexar metadata EXIF."
 
 #: QML
+msgid "Current folder (%1)"
+msgstr ""
+
+#: QML
 msgid "Current password"
 msgstr "Pled-clav actuala"
+
+#: QML
+msgid "Current search results (%1)"
+msgstr ""
 
 #: QML
 msgid "Custom tags"
@@ -1044,6 +1091,10 @@ msgid "Jump to this image in the Browse tab"
 msgstr ""
 
 #: QML
+msgid "Keep target tags and add missing source tags"
+msgstr ""
+
+#: QML
 msgid "Language"
 msgstr "Lingua"
 
@@ -1076,6 +1127,10 @@ msgstr "METADATA"
 #: QML
 msgid "Managed Folders"
 msgstr "Cartellas manasgiadas"
+
+#: QML
+msgid "Marked images (%1)"
+msgstr "Maletgs marcads (%1)"
 
 #: QML
 msgid "Meaning"
@@ -1318,6 +1373,10 @@ msgid "Remove from selected image"
 msgstr "Allontanar dal maletg selecziunà"
 
 #: QML
+msgid "Remove target tags before copying source tags"
+msgstr ""
+
+#: QML
 msgid "Remove this folder and delete its indexed images"
 msgstr "Stizzar questa cartella e ses maletgs indexads"
 
@@ -1333,6 +1392,14 @@ msgstr ""
 #: QML
 msgid "Render preview-cache JPEGs for this folder"
 msgstr "Render JPEGs dal cache da previstas per questa cartella"
+
+#: QML
+msgid "Replace"
+msgstr ""
+
+#: QML
+msgid "Replace tags on target images?"
+msgstr ""
 
 #: QML
 msgid "Rescan"

--- a/src/exif_turbo/tagging/tagging_service.py
+++ b/src/exif_turbo/tagging/tagging_service.py
@@ -67,6 +67,11 @@ class TagMembership(StrEnum):
     SOME = "some"
 
 
+class CopyTagsMode(StrEnum):
+    ADD = "add"
+    REPLACE = "replace"
+
+
 @dataclass(frozen=True)
 class TagMutationResult:
     image_path: str
@@ -302,6 +307,36 @@ class TaggingService:
             cancel_check=cancel_check,
         )
 
+    def copy_tags_to_paths(
+        self,
+        source_image_path: str,
+        target_image_paths: Iterable[str],
+        mode: CopyTagsMode,
+        *,
+        on_progress: BulkProgress | None = None,
+        cancel_check: Callable[[], bool] | None = None,
+    ) -> BulkTagResult:
+        source_state = self.get_image_tagging_state(source_image_path)
+        source_sidecar = source_state.sidecar
+        source_tags = () if source_sidecar is None else source_sidecar.tags
+        source_free_tags = () if source_sidecar is None else source_sidecar.free_tags
+        targets = (
+            path
+            for path in target_image_paths
+            if path != source_image_path
+        )
+        return self._bulk_apply(
+            targets,
+            lambda path: self._copy_tags_to_path(
+                path,
+                source_tags,
+                source_free_tags,
+                mode,
+            ),
+            on_progress=on_progress,
+            cancel_check=cancel_check,
+        )
+
     def accept_auto_candidates(
         self,
         batch: ProposalBatchResult,
@@ -388,6 +423,42 @@ class TaggingService:
             revision,
             accepted_proposals=accepted_proposals,
         )
+        return TagMutationResult(image_path, True, updated)
+
+    def _copy_tags_to_path(
+        self,
+        image_path: str,
+        source_tags: tuple[ImageTag, ...],
+        source_free_tags: tuple[str, ...],
+        mode: CopyTagsMode,
+    ) -> TagMutationResult:
+        path = Path(image_path)
+        loaded = self._read_sidecar(path)
+        sidecar = self._load_or_create_sidecar(path, loaded)
+        if mode is CopyTagsMode.REPLACE:
+            tags = self._ordered_tags(source_tags)
+            free_tags = source_free_tags
+        elif mode is CopyTagsMode.ADD:
+            tags_by_id = {tag.concept_id: tag for tag in sidecar.tags}
+            for tag in source_tags:
+                tags_by_id.setdefault(tag.concept_id, tag)
+            tags = self._ordered_tags(tuple(tags_by_id.values()))
+            free_tags_by_key = {tag.casefold(): tag for tag in sidecar.free_tags}
+            for tag in source_free_tags:
+                free_tags_by_key.setdefault(tag.casefold(), tag)
+            free_tags = tuple(free_tags_by_key.values())
+        else:
+            raise ValueError(f"unknown copy tags mode: {mode}")
+        if tags == sidecar.tags and free_tags == sidecar.free_tags:
+            return TagMutationResult(image_path, False, sidecar)
+        updated = replace(
+            sidecar,
+            updated_at=self._timestamp(),
+            tags=tags,
+            free_tags=free_tags,
+        )
+        revision = self._write_sidecar(path, updated, loaded)
+        self._update_cache(image_path, updated, revision)
         return TagMutationResult(image_path, True, updated)
 
     def _apply_auto_generation(

--- a/src/exif_turbo/ui/qml/Main.qml
+++ b/src/exif_turbo/ui/qml/Main.qml
@@ -1291,6 +1291,7 @@ ApplicationWindow {
         appController: controller
         appSettings: settingsModel
         selectedFilename: controller ? controller.selectedFilename : ""
+        browseMode: mainTabBar.currentIndex === 1
     }
 
     // ── Search tab ───────────────────────────────────────────────────────

--- a/src/exif_turbo/ui/qml/TaggingDrawer.qml
+++ b/src/exif_turbo/ui/qml/TaggingDrawer.qml
@@ -17,11 +17,32 @@ Drawer {
     required property var appController
     required property var appSettings
     property string selectedFilename: ""
+    property bool browseMode: false
     property bool showFreeTagSuggestions: false
     readonly property bool hasSelection: appController && appController.currentResultRow >= 0
     readonly property bool locallyBusy: appController && (
         appController.isTgmUpdating
-        || appController.isGeneratingTagProposals)
+        || appController.isGeneratingTagProposals
+        || appController.isTaggingBulk)
+
+    onBrowseModeChanged: copyTarget.currentIndex = 0
+
+    Dialog {
+        id: replaceTagsDialog
+        objectName: "replaceTagsDialog"
+        property string targetScope: ""
+        title: qsTr("Replace tags on target images?")
+        modal: true
+        standardButtons: Dialog.Ok | Dialog.Cancel
+        anchors.centerIn: parent
+        onAccepted: appController.copySelectedTags(targetScope, "replace")
+
+        Label {
+            width: Math.min(340, replaceTagsDialog.availableWidth)
+            text: qsTr("All accepted and custom tags on each target image will be replaced. This cannot be undone.")
+            wrapMode: Text.WordWrap
+        }
+    }
 
     function openAndFocus() {
         open()
@@ -434,8 +455,6 @@ Drawer {
                         }
                     }
 
-                    Rectangle { Layout.fillWidth: true; height: 1; color: Material.dividerColor }
-
                     ColumnLayout {
                         Layout.fillWidth: true
                         Layout.margins: 14
@@ -565,6 +584,90 @@ Drawer {
                             }
                         }
                     }
+
+                    Rectangle { Layout.fillWidth: true; height: 1; color: Material.dividerColor }
+
+                    ColumnLayout {
+                        Layout.fillWidth: true
+                        Layout.margins: 14
+                        spacing: 8
+
+                        Label {
+                            text: qsTr("Copy tags to other images")
+                            font.pixelSize: 13
+                            font.weight: Font.DemiBold
+                        }
+                        Label {
+                            Layout.fillWidth: true
+                            text: qsTr("Copies accepted and custom tags. The current image is excluded.")
+                            wrapMode: Text.WordWrap
+                            font.pixelSize: 10
+                            opacity: 0.55
+                        }
+                        ComboBox {
+                            id: copyTarget
+                            objectName: "copyTagsTarget"
+                            Layout.fillWidth: true
+                            currentIndex: 0
+                            textRole: "text"
+                            valueRole: "value"
+                            model: drawer.browseMode
+                                ? [
+                                    { text: qsTr("Marked images (%1)").arg(appController.checkedCount), value: "marked" },
+                                    { text: qsTr("Current folder (%1)").arg(appController.totalResults), value: "folder" }
+                                ]
+                                : [
+                                    { text: qsTr("Marked images (%1)").arg(appController.checkedCount), value: "marked" },
+                                    { text: qsTr("Current search results (%1)").arg(appController.totalResults), value: "results" }
+                                ]
+                        }
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 14
+                            ButtonGroup { id: copyModeGroup }
+                            RadioButton {
+                                id: copyAddMode
+                                objectName: "copyTagsAddMode"
+                                text: qsTr("Add")
+                                checked: true
+                                ButtonGroup.group: copyModeGroup
+                                ToolTip.text: qsTr("Keep target tags and add missing source tags")
+                                ToolTip.visible: hovered
+                            }
+                            RadioButton {
+                                id: copyReplaceMode
+                                objectName: "copyTagsReplaceMode"
+                                text: qsTr("Replace")
+                                ButtonGroup.group: copyModeGroup
+                                ToolTip.text: qsTr("Remove target tags before copying source tags")
+                                ToolTip.visible: hovered
+                            }
+                            Item { Layout.fillWidth: true }
+                        }
+                        Button {
+                            objectName: "copyTagsButton"
+                            Layout.fillWidth: true
+                            text: qsTr("Copy Tags")
+                            highlighted: true
+                            enabled: drawer.hasSelection && !drawer.locallyBusy
+                            onClicked: {
+                                if (copyReplaceMode.checked) {
+                                    replaceTagsDialog.targetScope = copyTarget.currentValue
+                                    replaceTagsDialog.open()
+                                } else {
+                                    appController.copySelectedTags(copyTarget.currentValue, "add")
+                                }
+                            }
+                        }
+                        Label {
+                            Layout.fillWidth: true
+                            visible: appController.taggingBulkSummary !== ""
+                            text: appController.taggingBulkSummary
+                            wrapMode: Text.WordWrap
+                            font.pixelSize: 10
+                            opacity: 0.7
+                        }
+                    }
                 }
 
                 ColumnLayout {
@@ -576,8 +679,10 @@ Drawer {
                         Layout.fillWidth: true
                         from: 0
                         to: Math.max(1, appController.isTgmUpdating ? appController.tgmUpdateTotal
+                            : appController.isTaggingBulk ? appController.taggingBulkTotal
                             : appController.proposalGenerationTotal)
                         value: appController.isTgmUpdating ? appController.tgmUpdateCurrent
+                            : appController.isTaggingBulk ? appController.taggingBulkCurrent
                             : appController.proposalGenerationCurrent
                         indeterminate: to <= 1
                     }
@@ -586,6 +691,7 @@ Drawer {
                         Label {
                             Layout.fillWidth: true
                             text: appController.isTgmUpdating ? qsTr("Updating TGM")
+                                : appController.isTaggingBulk ? qsTr("Copying tags")
                                 : qsTr("Generating proposals")
                             font.pixelSize: 11
                         }
@@ -593,6 +699,7 @@ Drawer {
                             text: qsTr("Cancel")
                             onClicked: {
                                 if (appController.isTgmUpdating) appController.cancelTgmOperation()
+                                else if (appController.isTaggingBulk) appController.cancelBulkTagging()
                                 else appController.cancelTagProposalGeneration()
                             }
                         }

--- a/src/exif_turbo/ui/view_models/app_controller.py
+++ b/src/exif_turbo/ui/view_models/app_controller.py
@@ -77,6 +77,7 @@ from ..workers.ai_scan_worker import AiScanWorker
 from ..workers.ai_search_worker import AiSearchWorker
 from ..workers.bulk_op_worker import BulkOpWorker
 from ..workers.bulk_tag_worker import BulkTagWorker
+from ..workers.copy_tags_worker import CopyTagsWorker
 from ..workers.derivative_export_worker import DerivativeExportWorker
 from ..workers.folder_tree_worker import FolderTreeWorker
 from ..workers.index_worker import IndexWorker
@@ -391,6 +392,7 @@ class AppController(QObject):
         self._tgm_vector_worker: TgmVectorBuildWorker | None = None
         self._proposal_worker: TgmProposalWorker | None = None
         self._bulk_tag_worker: BulkTagWorker | None = None
+        self._copy_tags_worker: CopyTagsWorker | None = None
         self._derivative_worker: DerivativeExportWorker | None = None
         # Timer: kick off a batch thumb build while indexing runs. Fires 5 s
         # after indexing begins so the DB has a first batch of rows to process.
@@ -3932,6 +3934,69 @@ class AppController(QObject):
     def removeConceptFromMarked(self, concept_id: str) -> None:
         self._start_bulk_tag("remove", concept_id)
 
+    @Slot(str, str)
+    def copySelectedTags(self, target_scope: str, mode: str) -> None:
+        source_path = self._search_model.get_path(self._current_result_row)
+        if (
+            source_path is None
+            or not self.freeTaggingAvailable
+            or self._repo is None
+            or self._copy_tags_worker is not None
+            or self._bulk_tag_worker is not None
+        ):
+            return
+        if mode not in {"add", "replace"}:
+            self._bulk_tag_summary = _("Choose whether to add or replace tags.")
+            self.bulkTagOperationChanged.emit()
+            return
+        worker_kwargs: dict[str, object] = {}
+        if target_scope == "marked":
+            worker_kwargs = {
+                "marked_only": True,
+                "restrict_to_enabled_folders": self._folder_repo is not None,
+            }
+        elif target_scope in {"results", "folder"}:
+            if target_scope == "folder" and not self._folder_filter:
+                self._bulk_tag_summary = _("Choose a folder in Browse first.")
+                self.bulkTagOperationChanged.emit()
+                return
+            if self._results_use_ai_pipeline():
+                worker_kwargs = {
+                    "image_paths": [result.path for result in self._ai_result_cache]
+                }
+            else:
+                worker_kwargs = {
+                    "query": self._query_text,
+                    "ext_filter": self._ext_filter,
+                    "path_filter": self._current_path_filter(),
+                    "restrict_to_enabled_folders": self._folder_repo is not None,
+                    "date_from": self._date_from,
+                    "date_to": self._date_to,
+                }
+        else:
+            self._bulk_tag_summary = _("Choose a valid copy target.")
+            self.bulkTagOperationChanged.emit()
+            return
+        worker = CopyTagsWorker(
+            self._db_path,
+            self._key,
+            source_path,
+            mode,
+            **worker_kwargs,
+        )
+        self._copy_tags_worker = worker
+        worker.progress.connect(self._on_bulk_tag_progress)
+        worker.result_ready.connect(self._on_bulk_tag_result)
+        worker.failed.connect(self._on_bulk_tag_failed)
+        worker.canceled.connect(self._on_bulk_tag_result)
+        worker.finished.connect(lambda: self._release_worker("_copy_tags_worker", worker))
+        self._bulk_tag_operation = True
+        self._bulk_tag_progress = (0, 0)
+        self._bulk_tag_summary = ""
+        self._bulk_tag_action = f"copy_{mode}"
+        self.bulkTagOperationChanged.emit()
+        worker.start()
+
     def _start_bulk_tag(self, operation: str, concept_reference: str) -> None:
         if (
             not self.taggingAvailable
@@ -3968,6 +4033,10 @@ class AppController(QObject):
             summary = _("Removed from {} image(s). Already absent: {}. Problems: {}.").format(
                 changed_count, unchanged_count, problem_count
             )
+        elif self._bulk_tag_action.startswith("copy_"):
+            summary = _("Copied tags to {} image(s). Unchanged: {}. Problems: {}.").format(
+                changed_count, unchanged_count, problem_count
+            )
         else:
             summary = _("Added to {} image(s). Already tagged: {}. Problems: {}.").format(
                 changed_count, unchanged_count, problem_count
@@ -3985,8 +4054,9 @@ class AppController(QObject):
 
     @Slot()
     def cancelBulkTagging(self) -> None:
-        if self._bulk_tag_worker is not None:
-            self._bulk_tag_worker.cancel()
+        worker = self._copy_tags_worker or self._bulk_tag_worker
+        if worker is not None:
+            worker.cancel()
 
     @Slot(str)
     def generateDerivativesForMarked(self, output_url: str) -> None:
@@ -4129,6 +4199,7 @@ class AppController(QObject):
             self._tgm_vector_worker,
             self._proposal_worker,
             self._bulk_tag_worker,
+            self._copy_tags_worker,
             self._derivative_worker,
         ):
             if worker is not None and worker.isRunning():
@@ -4587,6 +4658,7 @@ class AppController(QObject):
         self._tgm_vector_worker = None
         self._proposal_worker = None
         self._bulk_tag_worker = None
+        self._copy_tags_worker = None
         self._derivative_worker = None
         self._tagging_service = None
         self._tgm_repository = None

--- a/src/exif_turbo/ui/workers/copy_tags_worker.py
+++ b/src/exif_turbo/ui/workers/copy_tags_worker.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from pathlib import Path
+
+from PySide6.QtCore import QThread, Signal
+
+from ...config import tgm_snapshot_path
+from ...data.image_index_repository import ImageIndexRepository
+from ...tagging.sidecar_repository import FilesystemSidecarRepository
+from ...tagging.tagging_service import CopyTagsMode, TaggingService
+from ...tagging.tgm_snapshot_repository import TgmSnapshotRepository
+
+
+class CopyTagsWorker(QThread):
+    progress = Signal(int, int, object)
+    result_ready = Signal(object)
+    failed = Signal(str)
+    canceled = Signal(object)
+
+    def __init__(
+        self,
+        db_path: Path,
+        key: str,
+        source_image_path: str,
+        mode: str,
+        *,
+        image_paths: Iterable[str] | None = None,
+        marked_only: bool = False,
+        query: str = "",
+        ext_filter: str = "",
+        path_filter: Iterable[str] | None = None,
+        restrict_to_enabled_folders: bool = False,
+        date_from: int | None = None,
+        date_to: int | None = None,
+    ) -> None:
+        super().__init__()
+        self._db_path = db_path
+        self._key = key
+        self._source_image_path = source_image_path
+        self._mode = CopyTagsMode(mode)
+        self._image_paths = None if image_paths is None else tuple(image_paths)
+        self._marked_only = marked_only
+        self._query = query
+        self._ext_filter = ext_filter
+        self._path_filter = None if path_filter is None else list(path_filter)
+        self._restrict_to_enabled_folders = restrict_to_enabled_folders
+        self._date_from = date_from
+        self._date_to = date_to
+        self._cancel_event = threading.Event()
+
+    def cancel(self) -> None:
+        self._cancel_event.set()
+
+    def run(self) -> None:
+        image_repository: ImageIndexRepository | None = None
+        try:
+            image_repository = ImageIndexRepository(self._db_path, key=self._key)
+            image_paths = self._image_paths
+            if image_paths is None:
+                if self._marked_only:
+                    image_paths = image_repository.get_marked_paths(
+                        restrict_to_enabled_folders=self._restrict_to_enabled_folders
+                    )
+                else:
+                    image_paths = image_repository.get_matching_paths(
+                        self._query,
+                        ext_filter=self._ext_filter,
+                        path_filter=self._path_filter,
+                        restrict_to_enabled_folders=self._restrict_to_enabled_folders,
+                        date_from=self._date_from,
+                        date_to=self._date_to,
+                    )
+            result = TaggingService(
+                image_repository,
+                FilesystemSidecarRepository(),
+                TgmSnapshotRepository(tgm_snapshot_path(self._db_path)),
+            ).copy_tags_to_paths(
+                self._source_image_path,
+                image_paths,
+                self._mode,
+                on_progress=self.progress.emit,
+                cancel_check=self._cancel_event.is_set,
+            )
+            if result.cancelled:
+                self.canceled.emit(result)
+            else:
+                self.result_ready.emit(result)
+        except Exception as exc:  # noqa: BLE001
+            self.failed.emit(str(exc))
+        finally:
+            if image_repository is not None:
+                image_repository.close()

--- a/tests/tagging/test_tagging_service.py
+++ b/tests/tagging/test_tagging_service.py
@@ -22,6 +22,7 @@ from exif_turbo.tagging.sidecar_repository import (
 )
 from exif_turbo.tagging.tagging_service import (
     BulkTagStatus,
+    CopyTagsMode,
     TagMembership,
     TaggingConflictError,
     TaggingFreeTagError,
@@ -88,6 +89,25 @@ def _service(
         image_repository,
         image_path,
     )
+
+
+def _add_indexed_image(
+    image_repository: ImageIndexRepository,
+    tmp_path: Path,
+    filename: str,
+) -> Path:
+    image_path = tmp_path / filename
+    image_path.write_bytes(f"image bytes for {filename}".encode())
+    image_stat = image_path.stat()
+    image_repository.upsert_image(
+        str(image_path),
+        image_path.name,
+        image_stat.st_mtime,
+        image_stat.st_size,
+        {},
+        "",
+    )
+    return image_path
 
 
 def test_tagging_service_add_alias_creates_canonical_sidecar_and_cache(
@@ -224,6 +244,90 @@ def test_tagging_service_add_duplicate_free_tag_ignoring_case_is_no_op(
     # Assert
     assert result.changed is False
     assert result.sidecar.free_tags == ("Family",)
+
+
+def test_tagging_service_copy_tags_add_merges_deduplicates_and_excludes_source(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    service, image_repository, source_path = _service(tmp_path)
+    target_path = _add_indexed_image(image_repository, tmp_path, "target.jpg")
+    service.add_concept(str(source_path), "Deer")
+    service.add_free_tag(str(source_path), "Family")
+    service.add_concept(str(target_path), "Photographs")
+    service.add_free_tag(str(target_path), "family")
+    service.add_free_tag(str(target_path), "Archive")
+
+    # Act
+    result = service.copy_tags_to_paths(
+        str(source_path),
+        [str(source_path), str(target_path), str(target_path)],
+        CopyTagsMode.ADD,
+    )
+
+    # Assert
+    target = service.get_image_tagging_state(str(target_path)).sidecar
+    assert result.succeeded_count == 1
+    assert len(result.items) == 1
+    assert target is not None
+    assert {tag.label for tag in target.tags} == {"Deer", "Photographs"}
+    assert set(target.free_tags) == {"Family", "Archive"}
+    assert service.get_image_tagging_state(str(source_path)).sidecar is not None
+
+
+def test_tagging_service_copy_tags_replace_preserves_target_sidecar_metadata(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    service, image_repository, source_path = _service(tmp_path)
+    target_path = _add_indexed_image(image_repository, tmp_path, "target.jpg")
+    service.add_concept(str(source_path), "Deer")
+    service.add_free_tag(str(source_path), "Family")
+    target_tag = ImageTag(
+        concept_id="loc-tgm:tgm000002",
+        label="Photographs",
+        category="genre_format",
+        provenance=TagProvenance(
+            method="manual",
+            accepted_at="2026-08-01T00:00:00Z",
+            vocabulary_checksum="sha256:old",
+        ),
+    )
+    target_stat = target_path.stat()
+    FilesystemSidecarRepository().write(
+        target_path,
+        ImageSidecar(
+            source=SidecarSource(
+                filename=target_path.name,
+                size=target_stat.st_size,
+                mtime_ns=target_stat.st_mtime_ns,
+                extra={"source_extension": "keep"},
+            ),
+            updated_at="2026-08-01T00:00:00Z",
+            tags=(target_tag,),
+            free_tags=("Archive",),
+            extra={"top_extension": "keep"},
+        ),
+        expected_revision=None,
+    )
+
+    # Act
+    result = service.copy_tags_to_paths(
+        str(source_path),
+        [str(target_path)],
+        CopyTagsMode.REPLACE,
+    )
+
+    # Assert
+    target = result.items[0]
+    loaded = FilesystemSidecarRepository().read(target_path)
+    assert target.status is BulkTagStatus.SUCCEEDED
+    assert loaded is not None
+    assert [tag.label for tag in loaded.sidecar.tags] == ["Deer"]
+    assert loaded.sidecar.free_tags == ("Family",)
+    assert loaded.sidecar.source.filename == "target.jpg"
+    assert loaded.sidecar.source.extra == {"source_extension": "keep"}
+    assert loaded.sidecar.extra == {"top_extension": "keep"}
 
 
 def test_tagging_service_reuses_remembered_free_tag_spelling(

--- a/tests/ui/test_app_controller_tagging.py
+++ b/tests/ui/test_app_controller_tagging.py
@@ -639,6 +639,103 @@ class FakeDerivativeWorker(QObject):
         return False
 
 
+class FakeCopyTagsWorker(QObject):
+    progress = Signal(int, int, object)
+    result_ready = Signal(object)
+    canceled = Signal(object)
+    failed = Signal(str)
+    finished = Signal()
+    instances: list[FakeCopyTagsWorker] = []
+
+    def __init__(
+        self,
+        db_path: Path,
+        key: str,
+        source_image_path: str,
+        mode: str,
+        **options: object,
+    ) -> None:
+        super().__init__()
+        self.db_path = db_path
+        self.key = key
+        self.source_image_path = source_image_path
+        self.mode = mode
+        self.options = options
+        self.started = False
+        self.instances.append(self)
+
+    def start(self) -> None:
+        self.started = True
+
+    def cancel(self) -> None:
+        pass
+
+    def isRunning(self) -> bool:
+        return False
+
+
+def test_app_controller_copy_tags_folder_forwards_current_browse_scope(
+    tagging_controller: tuple[AppController, SearchListModel, Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    controller, _model, _db_path, image_path = tagging_controller
+    folder = tmp_path / "browse"
+    controller._folder_filter = str(folder)
+    controller._query_text = ""
+    controller._ext_filter = ".jpg"
+    controller._date_from = 100
+    controller._date_to = 200
+    FakeCopyTagsWorker.instances.clear()
+    monkeypatch.setattr(app_controller_module, "CopyTagsWorker", FakeCopyTagsWorker)
+
+    # Act
+    controller.copySelectedTags("folder", "replace")
+
+    # Assert
+    worker = FakeCopyTagsWorker.instances[0]
+    assert worker.source_image_path == str(image_path)
+    assert worker.mode == "replace"
+    assert worker.options == {
+        "query": "",
+        "ext_filter": ".jpg",
+        "path_filter": [str(folder)],
+        "restrict_to_enabled_folders": True,
+        "date_from": 100,
+        "date_to": 200,
+    }
+    assert worker.started is True
+
+
+def test_app_controller_copy_tags_results_uses_complete_ai_cache(
+    tagging_controller: tuple[AppController, SearchListModel, Path, Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    controller, _model, _db_path, image_path = tagging_controller
+    second_path = tmp_path / "second.jpg"
+    controller._is_ai_search_mode = True
+    controller._last_ai_query = "forest"
+    controller._ai_result_cache = [
+        SearchResult(str(image_path), image_path.name, "{}", 5, 1.0, 1),
+        SearchResult(str(second_path), second_path.name, "{}", 5, 1.0, 2),
+    ]
+    FakeCopyTagsWorker.instances.clear()
+    monkeypatch.setattr(app_controller_module, "CopyTagsWorker", FakeCopyTagsWorker)
+
+    # Act
+    controller.copySelectedTags("results", "add")
+
+    # Assert
+    worker = FakeCopyTagsWorker.instances[0]
+    assert worker.options == {
+        "image_paths": [str(image_path), str(second_path)]
+    }
+    assert worker.started is True
+
+
 def test_app_controller_derivative_slot_converts_url_and_all_indexed_roots(
     tagging_controller: tuple[AppController, SearchListModel, Path, Path],
     tmp_path: Path,

--- a/tests/ui/test_tagging_qml.py
+++ b/tests/ui/test_tagging_qml.py
@@ -55,6 +55,8 @@ def test_tagging_qml_contract_contains_required_controls_and_slots() -> None:
         "generateDerivativesForCurrentResults(",
         "generateDerivativesForMarked(",
         "cancelDerivativeExport(",
+        "copySelectedTags(",
+        "cancelBulkTagging(",
     }
 
     # Act
@@ -77,7 +79,20 @@ def test_tagging_qml_contract_contains_required_controls_and_slots() -> None:
     assert "appController.derivativeTagsModel" in source
     assert 'text: qsTr("Custom tags")' in drawer_source
     assert 'text: qsTr("Tags on current image")' in drawer_source
-    assert "Marked images" not in drawer_source
+    assert 'objectName: "copyTagsTarget"' in drawer_source
+    assert "onBrowseModeChanged: copyTarget.currentIndex = 0" in drawer_source
+    assert 'objectName: "copyTagsAddMode"' in drawer_source
+    assert 'objectName: "copyTagsReplaceMode"' in drawer_source
+    assert drawer_source.count("RadioButton {") >= 2
+    assert 'objectName: "copyTagsButton"' in drawer_source
+    assert 'objectName: "replaceTagsDialog"' in drawer_source
+    assert 'value: "results"' in drawer_source
+    assert 'value: "folder"' in drawer_source
+    assert 'value: "marked"' in drawer_source
+    assert "Marked images" in drawer_source
+    assert drawer_source.index('objectName: "copyTagsTarget"') > drawer_source.index(
+        'objectName: "pendingProposalsList"'
+    )
     assert "markedMode" not in drawer_source
     assert "applyConceptToMarked" not in drawer_source
     assert "removeConceptFromMarked" not in drawer_source
@@ -153,6 +168,9 @@ def test_main_qml_with_tagging_workbench_loads(
     assert root.findChild(QQuickItem, "addFreeTagButton") is not None
     assert root.findChild(QQuickItem, "freeTagSuggestions") is not None
     assert root.findChild(QQuickItem, "currentFreeTags") is not None
+    copy_target = root.findChild(QQuickItem, "copyTagsTarget")
+    assert copy_target is not None
+    assert copy_target.property("currentValue") == "marked"
 
     controller.close()
     engine.deleteLater()

--- a/tests/ui/test_tagging_workers.py
+++ b/tests/ui/test_tagging_workers.py
@@ -6,10 +6,12 @@ from types import SimpleNamespace
 import pytest
 
 from exif_turbo.ui.workers import bulk_tag_worker as bulk_module
+from exif_turbo.ui.workers import copy_tags_worker as copy_module
 from exif_turbo.ui.workers import tgm_proposal_worker as proposal_module
 from exif_turbo.ui.workers import tgm_update_worker as update_module
 from exif_turbo.ui.workers import tgm_vector_build_worker as vector_module
 from exif_turbo.ui.workers.bulk_tag_worker import BulkTagWorker
+from exif_turbo.ui.workers.copy_tags_worker import CopyTagsWorker
 from exif_turbo.ui.workers.tgm_proposal_worker import TgmProposalWorker
 from exif_turbo.ui.workers.tgm_update_worker import TgmUpdateWorker
 from exif_turbo.ui.workers.tgm_vector_build_worker import TgmVectorBuildWorker
@@ -138,6 +140,107 @@ def test_bulk_tag_worker_fake_service_emits_result_and_closes_repository(
     # Assert
     assert results == [result]
     assert repositories[0].closed is True
+
+
+def test_copy_tags_worker_marked_scope_resolves_marked_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    copied_paths: list[tuple[str, ...]] = []
+    result = SimpleNamespace(cancelled=False, succeeded_count=2)
+
+    class MarkedRepository(FakeRepository):
+        def get_marked_paths(self, **_kwargs: object) -> list[str]:
+            return ["first.jpg", "second.jpg"]
+
+    class FakeTaggingService:
+        def __init__(self, *args: object) -> None:
+            pass
+
+        def copy_tags_to_paths(
+            self,
+            _source: str,
+            paths: object,
+            _mode: object,
+            **_kwargs: object,
+        ) -> object:
+            copied_paths.append(tuple(paths))  # type: ignore[arg-type]
+            return result
+
+    monkeypatch.setattr(copy_module, "ImageIndexRepository", MarkedRepository)
+    monkeypatch.setattr(copy_module, "TaggingService", FakeTaggingService)
+    monkeypatch.setattr(copy_module, "TgmSnapshotRepository", FakeRepository)
+    worker = CopyTagsWorker(
+        tmp_path / "images.db",
+        "",
+        "source.jpg",
+        "add",
+        marked_only=True,
+    )
+    results: list[object] = []
+    worker.result_ready.connect(results.append)
+
+    # Act
+    worker.run()
+
+    # Assert
+    assert copied_paths == [("first.jpg", "second.jpg")]
+    assert results == [result]
+
+
+def test_copy_tags_worker_results_scope_forwards_complete_filters(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Arrange
+    matching_options: list[tuple[str, dict[str, object]]] = []
+    result = SimpleNamespace(cancelled=False, succeeded_count=1)
+
+    class MatchingRepository(FakeRepository):
+        def get_matching_paths(self, query: str, **kwargs: object) -> list[str]:
+            matching_options.append((query, kwargs))
+            return ["target.jpg"]
+
+    class FakeTaggingService:
+        def __init__(self, *args: object) -> None:
+            pass
+
+        def copy_tags_to_paths(self, *_args: object, **_kwargs: object) -> object:
+            return result
+
+    monkeypatch.setattr(copy_module, "ImageIndexRepository", MatchingRepository)
+    monkeypatch.setattr(copy_module, "TaggingService", FakeTaggingService)
+    monkeypatch.setattr(copy_module, "TgmSnapshotRepository", FakeRepository)
+    worker = CopyTagsWorker(
+        tmp_path / "images.db",
+        "",
+        "source.jpg",
+        "replace",
+        query="family",
+        ext_filter=".jpg",
+        path_filter=["photos"],
+        restrict_to_enabled_folders=True,
+        date_from=100,
+        date_to=200,
+    )
+
+    # Act
+    worker.run()
+
+    # Assert
+    assert matching_options == [
+        (
+            "family",
+            {
+                "ext_filter": ".jpg",
+                "path_filter": ["photos"],
+                "restrict_to_enabled_folders": True,
+                "date_from": 100,
+                "date_to": 200,
+            },
+        )
+    ]
 
 
 def test_maintenance_reset_removes_tgm_derivatives_and_preserves_sidecar(


### PR DESCRIPTION
## Summary
- copy accepted TGM and custom tags from the selected image to marked images, current search results, or the current Browse folder
- support add and replace modes with deduplication, source exclusion, and replace confirmation
- run bulk copying asynchronously with progress, cancellation, result summaries, and shutdown handling
- add the Copy Tags workflow to the bottom of the tagging drawer, defaulting to marked images
- update localization catalogs and focused regression coverage

## Tests
- pytest tests/tagging/test_tagging_service.py tests/ui/test_tagging_workers.py tests/ui/test_app_controller_tagging.py tests/ui/test_tagging_qml.py -q --timeout=120 --timeout-method=thread (52 passed)