### PR TITLE
Merge 1.17.0 runtime license staging fix into main

### DIFF
--- a/scripts/stage_runtime_licenses.py
+++ b/scripts/stage_runtime_licenses.py
@@ -25,6 +25,26 @@ _QT_DISTRIBUTIONS = {
     "pyside6-essentials",
     "shiboken6",
 }
+_UPSTREAM_PACKAGE_LICENSES = {
+    "sentencepiece": (
+        "Apache-2.0.txt",
+        "https://raw.githubusercontent.com/google/sentencepiece/v{version}/LICENSE",
+        "Apache-2.0",
+        "License :: OSI Approved :: Apache Software License",
+        "Apache License",
+        11_000,
+        "END OF TERMS AND CONDITIONS",
+    ),
+    "tokenizers": (
+        "Apache-2.0.txt",
+        "https://raw.githubusercontent.com/huggingface/tokenizers/v{version}/LICENSE",
+        "Apache-2.0",
+        "License :: OSI Approved :: Apache Software License",
+        "Apache License",
+        11_000,
+        "END OF TERMS AND CONDITIONS",
+    ),
+}
 _QT_LICENSES = {
     "GPL-2.0-only.txt": ("GNU GENERAL PUBLIC LICENSE", 17_000, "END OF TERMS AND CONDITIONS"),
     "GPL-3.0-only.txt": ("GNU GENERAL PUBLIC LICENSE", 34_000, "END OF TERMS AND CONDITIONS"),
@@ -140,6 +160,68 @@ def _license_files(package: Distribution) -> tuple[Path, ...]:
         if source.is_file():
             files.append(source)
     return tuple(sorted(set(files), key=lambda path: str(path).casefold()))
+
+
+def _upstream_package_license_files(package: Distribution) -> tuple[Path, ...]:
+    canonical_name = canonicalize_name(package.metadata["Name"])
+    specification = _UPSTREAM_PACKAGE_LICENSES.get(canonical_name)
+    if specification is None:
+        return ()
+    (
+        filename,
+        url_template,
+        expression,
+        classifier,
+        heading,
+        minimum_size,
+        required_text,
+    ) = specification
+    declared_expression = package.metadata.get("License-Expression")
+    declared_classifiers = package.metadata.get_all("Classifier") or []
+    if declared_expression != expression and classifier not in declared_classifiers:
+        raise LicenseStagingError(
+            f"expected {expression} declaration for {package.metadata['Name']} "
+            f"{package.version}"
+        )
+    cache_dir = (
+        REPO_ROOT
+        / "build"
+        / "license-cache"
+        / "python"
+        / canonical_name
+        / package.version
+    )
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    target = cache_dir / filename
+    if target.is_file():
+        cached = target.read_text(encoding="utf-8", errors="replace")
+        if (
+            len(cached.encode("utf-8")) >= minimum_size
+            and heading in cached
+            and required_text in cached
+        ):
+            return (target,)
+    url = url_template.format(version=package.version)
+    try:
+        with urllib.request.urlopen(url, timeout=60) as response:  # noqa: S310
+            contents = response.read()
+    except OSError as exc:
+        raise LicenseStagingError(
+            f"could not download {package.metadata['Name']} {package.version} "
+            "license text"
+        ) from exc
+    text = contents.decode("utf-8")
+    if (
+        len(contents) < minimum_size
+        or heading not in text
+        or required_text not in text
+    ):
+        raise LicenseStagingError(
+            f"downloaded license text is invalid: {package.metadata['Name']} "
+            f"{package.version}"
+        )
+    target.write_text(text, encoding="utf-8")
+    return (target,)
 
 
 def _safe_filename(path: Path, used: set[str]) -> str:
@@ -321,7 +403,7 @@ def stage_runtime_licenses(
 
     package_licenses: list[tuple[Distribution, tuple[Path, ...]]] = []
     for package in packages:
-        files = _license_files(package)
+        files = _license_files(package) or _upstream_package_license_files(package)
         if not files and canonicalize_name(package.metadata["Name"]) not in (
             _QT_DISTRIBUTIONS
         ):
@@ -347,7 +429,8 @@ def stage_runtime_licenses(
             "=======================================",
             "",
             "Generated from the active build environment. Each directory below",
-            "contains the unmodified license/notice files shipped by that distribution.",
+            "contains validated license/notice files for that distribution.",
+            "Version-matched upstream texts are used only when a wheel omits its license.",
             "Qt for Python wheels that omit these files reference validated upstream",
             "Qt license texts in the shared qt/<version> directory.",
             "",

--- a/tests/scripts/test_stage_runtime_licenses.py
+++ b/tests/scripts/test_stage_runtime_licenses.py
@@ -255,6 +255,85 @@ def test_stage_runtime_licenses_package_without_license_raises_error(
     )
 
 
+def test_stage_runtime_licenses_sentencepiece_without_license_uses_upstream_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    _write_project_notices(project_root)
+    package = FakeDistribution(tmp_path, "sentencepiece", "0.2.2")
+    package.metadata.replace_header("License-Expression", "Apache-2.0")
+    python_license = tmp_path / "PYTHON-LICENSE.txt"
+    python_license.write_text("Python terms", encoding="utf-8")
+    upstream_license = tmp_path / "Apache-2.0.txt"
+    upstream_license.write_text("Apache terms", encoding="utf-8")
+    monkeypatch.setattr(stage_runtime_licenses, "REPO_ROOT", project_root)
+    monkeypatch.setattr(
+        stage_runtime_licenses, "_python_license_file", lambda: python_license
+    )
+    monkeypatch.setattr(
+        stage_runtime_licenses,
+        "_upstream_package_license_files",
+        lambda _package: (upstream_license,),
+    )
+    monkeypatch.setattr(
+        stage_runtime_licenses,
+        "distribution",
+        lambda _name: _as_distribution(package),
+    )
+    output_dir = tmp_path / "staged"
+
+    # Act
+    stage_runtime_licenses.stage_runtime_licenses(
+        output_dir, requirements=("sentencepiece",)
+    )
+
+    # Assert
+    assert (
+        output_dir / "python" / "sentencepiece-0.2.2" / "Apache-2.0.txt"
+    ).read_text(encoding="utf-8") == "Apache terms"
+    manifest = (output_dir / "PYTHON-RUNTIME-LICENSES.txt").read_text(
+        encoding="utf-8"
+    )
+    assert "sentencepiece 0.2.2 [Apache-2.0]" in manifest
+    assert "python/sentencepiece-0.2.2/Apache-2.0.txt" in manifest
+
+
+def test_upstream_package_license_files_classifier_and_valid_cache_returns_text(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Arrange
+    package = FakeDistribution(tmp_path, "tokenizers", "0.22.2")
+    del package.metadata["License-Expression"]
+    package.metadata["Classifier"] = (
+        "License :: OSI Approved :: Apache Software License"
+    )
+    cached_license = (
+        tmp_path
+        / "build"
+        / "license-cache"
+        / "python"
+        / "tokenizers"
+        / "0.22.2"
+        / "Apache-2.0.txt"
+    )
+    cached_license.parent.mkdir(parents=True)
+    cached_license.write_text(
+        "Apache License\n" + ("license text\n" * 1_000) + "END OF TERMS AND CONDITIONS\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(stage_runtime_licenses, "REPO_ROOT", tmp_path)
+
+    # Act
+    result = stage_runtime_licenses._upstream_package_license_files(
+        _as_distribution(package)
+    )
+
+    # Assert
+    assert result == (cached_license,)
+
+
 def test_stage_runtime_licenses_qt_wheels_without_licenses_use_upstream_texts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- synchronize the post-release-branch runtime license staging fix back to main
- stage validated, version-matched Apache-2.0 texts for sentencepiece and tokenizers wheels that omit license payloads
- preserve fail-closed behavior for unknown packages and unexpected license declarations

## Validation
- 10 focused license-staging tests passed
- real staging completed for all 47 runtime distributions
- Windows 1.17.0 build completed and produced an audited MSI

Merged into release-1.17.0 via #66.