### PR TITLE
fix: restore AI Full Rescan in packaged apps

### DIFF
--- a/docs/releases/v1.17.0.md
+++ b/docs/releases/v1.17.0.md
@@ -1,0 +1,32 @@
+## What's changed in v1.17.0
+
+### Multilingual AI and Wikidata tagging
+
+- Replaced the user-facing Library of Congress TGM setup with a bundled, curated visual vocabulary of **8,313 Wikidata concepts**.
+- Added offline preferred labels and aliases in English, German, French, and Italian.
+- Added a separate metadata-language setting for controlled-vocabulary lookup, display, and derivative export, independent of the interface language.
+- Upgraded AI search and tagging to the multilingual XLM-R OpenCLIP model.
+- New controlled tags use stable Wikidata QIDs in sidecar schema v2. Existing schema-v1 `loc-tgm` sidecars remain readable, searchable, and exportable.
+- Removed the TGM download and translation-pack workflow. The bundled Wikidata vocabulary requires no separate installation.
+
+### Better tag proposals
+
+- Improved proposal recognition by scoring the full image and four overlapping corner crops against prompts in all four metadata languages.
+- Added clearer diagnostics for missing image vectors, stale vocabulary indexes, and searches with no results above the configured threshold.
+- Changed the default proposal threshold to **0.20** and the optional auto-accept threshold to **0.28**. Existing customized thresholds are preserved.
+- Auto-accept remains experimental, disabled by default, and opt-in.
+
+### Upgrade notes
+
+- Existing AI image indexes are incompatible with the new five-view format. Run **AI Full Rescan** for each relevant indexed folder after upgrading.
+- Open **Settings > Tagging and Controlled Vocabulary** and select **Build Vectors** or **Rebuild Vectors** before generating tag proposals.
+- First AI use may require network access to download the multilingual model and tokenizer. Later use works from the local cache.
+- Existing sidecars are not deleted or rewritten merely by upgrading.
+
+### Packaging and documentation
+
+- Fixed Windows release builds for `sentencepiece` and `tokenizers` wheels that omit packaged license files by staging validated, version-matched Apache 2.0 texts.
+- Strengthened release compliance checks for Python dependencies, Qt, libvips, CPython, and project notices.
+- Updated the user manual, screenshots, specifications, translations, and third-party licensing documentation for the Wikidata workflow.
+
+**Full changelog**: https://github.com/baddonkey/exif-turbo/compare/v1.16.0...v1.17.0

--- a/docs/releases/v1.17.1.md
+++ b/docs/releases/v1.17.1.md
@@ -1,0 +1,11 @@
+## What's changed in v1.17.1
+
+### Windows AI Full Rescan hotfix
+
+- Fixed AI Full Rescan in the installed Windows application by bundling OpenCLIP's required BPE vocabulary in the MSI.
+- Applied the same packaging correction to Debian, RPM, Intel macOS, and Apple silicon macOS builds.
+- Strengthened release audits so builds fail before publication when the required OpenCLIP vocabulary is missing.
+
+This hotfix is recommended for all v1.17.0 users who use AI search or tagging.
+
+**Full changelog**: https://github.com/baddonkey/exif-turbo/compare/v1.17.0...v1.17.1

--- a/exif-turbo-deb.spec
+++ b/exif-turbo-deb.spec
@@ -26,7 +26,10 @@ _common_datas = [
     (str(_license_dir), 'licenses'),
     ('docs/user-manual.pdf', 'exif_turbo/assets'),
     ('src/exif_turbo/i18n/locales', 'exif_turbo/i18n/locales'),
-    *collect_data_files('open_clip', includes=['model_configs/*.json']),
+    *collect_data_files(
+        'open_clip',
+        includes=['model_configs/*.json', 'bpe_simple_vocab_16e6.txt.gz'],
+    ),
 ]
 
 _common_hiddenimports = [

--- a/exif-turbo-macos-arm.spec
+++ b/exif-turbo-macos-arm.spec
@@ -32,7 +32,10 @@ a = Analysis(
         (str(_license_dir), 'licenses'),
         ('docs/user-manual.pdf', 'exif_turbo/assets'),
         ('src/exif_turbo/i18n/locales', 'exif_turbo/i18n/locales'),
-        *collect_data_files('open_clip', includes=['model_configs/*.json']),
+        *collect_data_files(
+            'open_clip',
+            includes=['model_configs/*.json', 'bpe_simple_vocab_16e6.txt.gz'],
+        ),
     ],
     hiddenimports=[
         'exif_turbo.ui',

--- a/exif-turbo-macos-intel.spec
+++ b/exif-turbo-macos-intel.spec
@@ -32,7 +32,10 @@ a = Analysis(
         (str(_license_dir), 'licenses'),
         ('docs/user-manual.pdf', 'exif_turbo/assets'),
         ('src/exif_turbo/i18n/locales', 'exif_turbo/i18n/locales'),
-        *collect_data_files('open_clip', includes=['model_configs/*.json']),
+        *collect_data_files(
+            'open_clip',
+            includes=['model_configs/*.json', 'bpe_simple_vocab_16e6.txt.gz'],
+        ),
     ],
     hiddenimports=[
         'exif_turbo.ui',

--- a/exif-turbo-rpm.spec
+++ b/exif-turbo-rpm.spec
@@ -26,7 +26,10 @@ _common_datas = [
     (str(_license_dir), 'licenses'),
     ('docs/user-manual.pdf', 'exif_turbo/assets'),
     ('src/exif_turbo/i18n/locales', 'exif_turbo/i18n/locales'),
-    *collect_data_files('open_clip', includes=['model_configs/*.json']),
+    *collect_data_files(
+        'open_clip',
+        includes=['model_configs/*.json', 'bpe_simple_vocab_16e6.txt.gz'],
+    ),
 ]
 
 _common_hiddenimports = [

--- a/exif-turbo.spec
+++ b/exif-turbo.spec
@@ -35,7 +35,10 @@ _common_datas = [
     (str(_license_dir), 'licenses'),
     ('docs\\user-manual.pdf', 'exif_turbo\\assets'),
     ('src\\exif_turbo\\i18n\\locales', 'exif_turbo\\i18n\\locales'),
-    *collect_data_files('open_clip', includes=['model_configs/*.json']),
+    *collect_data_files(
+        'open_clip',
+        includes=['model_configs/*.json', 'bpe_simple_vocab_16e6.txt.gz'],
+    ),
 ]
 
 _common_hiddenimports = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "exif-turbo"
-version = "1.17.1"
+version = "1.17.2"
 description = "Fast EXIF full-text search with a PySide6 UI"
 requires-python = ">=3.11"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "exif-turbo"
-version = "1.17.0"
+version = "1.17.1"
 description = "Fast EXIF full-text search with a PySide6 UI"
 requires-python = ">=3.11"
 dependencies = [

--- a/scripts/audit_release_artifact.py
+++ b/scripts/audit_release_artifact.py
@@ -117,6 +117,7 @@ def audit_release_payload(
         for path in files
         if not path.is_relative_to(license_root) and path.stat().st_size > 0
     ]
+    _require_file(runtime_files, "open_clip/bpe_simple_vocab_16e6.txt.gz")
 
     runtime_by_name = {path.name.casefold(): path for path in runtime_files}
     native_hash_entries = (libvips_license_dir / "NATIVE-FILES.sha256").read_text(

--- a/src/exif_turbo/__init__.py
+++ b/src/exif_turbo/__init__.py
@@ -1,6 +1,6 @@
 """exif-turbo — Cross-platform image EXIF metadata search and indexing tool."""
 
-__version__ = "1.17.0"
+__version__ = "1.17.1"
 
 from .data.image_index_repository import ImageIndexRepository
 from .indexing.exif_metadata_extractor import ExifMetadataExtractor

--- a/src/exif_turbo/__init__.py
+++ b/src/exif_turbo/__init__.py
@@ -1,6 +1,6 @@
 """exif-turbo — Cross-platform image EXIF metadata search and indexing tool."""
 
-__version__ = "1.17.1"
+__version__ = "1.17.2"
 
 from .data.image_index_repository import ImageIndexRepository
 from .indexing.exif_metadata_extractor import ExifMetadataExtractor

--- a/tests/scripts/test_audit_release_artifact.py
+++ b/tests/scripts/test_audit_release_artifact.py
@@ -42,6 +42,9 @@ def _write_compliant_payload(root: Path) -> None:
     (licenses / "STAGING-COMPLETE").write_text("complete\n", encoding="ascii")
     (root / "_internal" / "libvips-42.dll").write_bytes(b"binary")
     (root / "_internal" / "Qt6Core.dll").write_bytes(b"binary")
+    bpe_vocab = root / "_internal" / "open_clip" / "bpe_simple_vocab_16e6.txt.gz"
+    bpe_vocab.parent.mkdir(parents=True)
+    bpe_vocab.write_bytes(b"vocabulary")
 
 
 def test_audit_release_payload_complete_payload_succeeds(tmp_path: Path) -> None:
@@ -50,6 +53,26 @@ def test_audit_release_payload_complete_payload_succeeds(tmp_path: Path) -> None
 
     # Act / Assert
     audit_release_payload(tmp_path)
+
+
+def test_audit_release_payload_missing_open_clip_bpe_vocab_raises_error(
+    tmp_path: Path,
+) -> None:
+    # Arrange
+    _write_compliant_payload(tmp_path)
+    (
+        tmp_path
+        / "_internal"
+        / "open_clip"
+        / "bpe_simple_vocab_16e6.txt.gz"
+    ).unlink()
+
+    # Act / Assert
+    with pytest.raises(
+        ArtifactAuditError,
+        match="open_clip/bpe_simple_vocab_16e6.txt.gz",
+    ):
+        audit_release_payload(tmp_path)
 
 
 def test_audit_release_payload_bundled_tgm_data_raises_error(tmp_path: Path) -> None:

--- a/version_info.py
+++ b/version_info.py
@@ -1,8 +1,8 @@
 # Auto-generated from exif-turbo.spec — do not edit manually.
 VSVersionInfo(
     ffi=FixedFileInfo(
-        filevers=(1, 17, 1, 0),
-        prodvers=(1, 17, 1, 0),
+        filevers=(1, 17, 2, 0),
+        prodvers=(1, 17, 2, 0),
         mask=0x3F,
         flags=0x0,
         OS=0x40004,
@@ -18,12 +18,12 @@ VSVersionInfo(
                     [
                         StringStruct("CompanyName", "exif-turbo"),
                         StringStruct("FileDescription", "exif-turbo — Image EXIF metadata search and indexing tool"),
-                        StringStruct("FileVersion", "1.17.1"),
+                        StringStruct("FileVersion", "1.17.2"),
                         StringStruct("InternalName", "exif-turbo"),
                         StringStruct("LegalCopyright", "Copyright (c) 2025 exif-turbo contributors"),
                         StringStruct("OriginalFilename", "exif-turbo.exe"),
                         StringStruct("ProductName", "exif-turbo"),
-                        StringStruct("ProductVersion", "1.17.1"),
+                        StringStruct("ProductVersion", "1.17.2"),
                     ],
                 )
             ]

--- a/version_info.py
+++ b/version_info.py
@@ -1,8 +1,8 @@
 # Auto-generated from exif-turbo.spec — do not edit manually.
 VSVersionInfo(
     ffi=FixedFileInfo(
-        filevers=(1, 17, 0, 0),
-        prodvers=(1, 17, 0, 0),
+        filevers=(1, 17, 1, 0),
+        prodvers=(1, 17, 1, 0),
         mask=0x3F,
         flags=0x0,
         OS=0x40004,
@@ -18,12 +18,12 @@ VSVersionInfo(
                     [
                         StringStruct("CompanyName", "exif-turbo"),
                         StringStruct("FileDescription", "exif-turbo — Image EXIF metadata search and indexing tool"),
-                        StringStruct("FileVersion", "1.17.0"),
+                        StringStruct("FileVersion", "1.17.1"),
                         StringStruct("InternalName", "exif-turbo"),
                         StringStruct("LegalCopyright", "Copyright (c) 2025 exif-turbo contributors"),
                         StringStruct("OriginalFilename", "exif-turbo.exe"),
                         StringStruct("ProductName", "exif-turbo"),
-                        StringStruct("ProductVersion", "1.17.0"),
+                        StringStruct("ProductVersion", "1.17.1"),
                     ],
                 )
             ]


### PR DESCRIPTION
## Summary

- bundle OpenCLIP's required BPE vocabulary in Windows, Debian, RPM, and macOS packages
- fail release audits when the vocabulary is missing from an assembled payload
- bump the patch release to v1.17.1 and add hotfix notes

## Root cause

The PyInstaller specs collected only OpenCLIP model configuration JSON files. OpenCLIP also reads its root bpe_simple_vocab_16e6.txt.gz package resource during import, so the installed v1.17.0 MSI failed AI Full Rescan with FileNotFoundError.

## Validation

- 7 release-audit tests passed
- PyInstaller resolves exactly one BPE vocabulary to the open_clip destination
- rebuilt Windows onedir payload passed the strengthened audit
- rebuilt MSI passed administrative extraction and installed-payload audit
- generated version_info.py matches the canonical v1.17.1 generator output